### PR TITLE
Add focusableInTouchMode to widget labels

### DIFF
--- a/java/res/layout/address_textview.xml
+++ b/java/res/layout/address_textview.xml
@@ -22,4 +22,5 @@
     android:layout_height="wrap_content"
     android:layout_marginTop="4dip"
     android:layout_marginLeft="3dip"
-    android:textColor="?android:attr/textColorPrimary" />
+    android:textColor="?android:attr/textColorPrimary"
+    android:focusableInTouchMode="true" />


### PR DESCRIPTION
See http://crbug.com/429344 for an explanation of why this is necessary.

Note that I have not actually tested this proposed change. On Chrome, it appears to be necessary to set it in Java rather than xml (TextView.setFocusableInTouchMode()), but I'm not sure why.
