### PR TITLE
Java codebase cleanup.

### DIFF
--- a/java/src/com/android/i18n/addressinput/AddressData.java
+++ b/java/src/com/android/i18n/addressinput/AddressData.java
@@ -16,194 +16,363 @@
 
 package com.android.i18n.addressinput;
 
+import static com.android.i18n.addressinput.Util.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * A simple data structure for international postal addresses.
- *
+ * An immutable data structure for international postal addresses, built using the nested
+ * {@link Builder} class.
+ * <p>
  * Addresses may seem simple, but even within the US there are many quirks (hyphenated street
  * addresses, etc.), and internationally addresses vary a great deal. The most sane and complete in
  * many ways is the OASIS "extensible Address Language", xAL, which is a published and documented
- * XML schema:
- *
- * http://www.oasis-open.org/committees/ciq/download.shtml
- *
- * We have not represented all the fields, but the intent is that if you need to add something, you
- * should follow the OASIS standard.
- *
+ * XML schema:<br>
+ * <a href="http://www.oasis-open.org/committees/ciq/download.shtml">
+ * http://www.oasis-open.org/committees/ciq/download.shtml</a>
+ * <p>
  * An example address:
- * <p>postalCountry: US</p>
- * <p>addressLine1: 1098 Alta Ave</p>
- * <p>addressLine2:</p>
- * <p>adminstrativeArea: CA</p>
- * <p>locality: Mountain View</p>
- * <p>dependentLocality:</p>
- * <p>postalCode: 94043</p>
- * <p>sortingCode:</p>
- * <p>organization: Google</p>
- * <p>recipient: Chen-Kang Yang</p>
- * <p>language code: en</p>
- *
- * Note that sub-administrative area is NOT used in Address Widget. Sub-administrative Area is
- * second-level administrative subdivision of this country. For examples: US county, IT province, UK
- * county. This level of geo information is not required to fill out address form, therefore is
- * neglected.
- *
- * All values stored in this class are trimmed. Also, if you try to set a field with an empty string
- * or a string consists of only spaces, it will not be set.
+ * <pre>
+ * postalCountry: US
+ * streetAddress: 1098 Alta Ave
+ * adminstrativeArea: CA
+ * locality: Mountain View
+ * dependentLocality:
+ * postalCode: 94043
+ * sortingCode:
+ * organization: Google
+ * recipient: Chen-Kang Yang
+ * language code: en
+ * </pre>
+ * <p>
+ * When using this class it's advised to do as little pre- or post-processing of the fields as
+ * possible. Typically we expect instances of this class to be used by the address widget and then
+ * transmitted or converted to other representations using the standard conversion libraries or
+ * formatted using one of the supported formatters. Attempting to infer semantic information from
+ * the values of the fields in this class is generally a bad idea.
+ * <p>
+ * Specifically the {@link #getFieldValue(AddressField)} is a problematic API as it encourages the
+ * belief that it is semantically correct to iterate over the fields in order. In general it should
+ * not be necessary to iterate over the fields in this class; instead use just the specific getter
+ * methods for the fields you need.
+ * <p>
+ * There are valid use cases for examining individual fields, but these are almost always region
+ * dependent:
+ * <ul>
+ * <li>Finding the region of the address. This is really the only completely safe field you can
+ * examine which gives an unambiguous and well defined result under all circumstances.
+ * <li>Testing if two addresses have the same administrative area. This is only reliable if the
+ * data was entered via a drop-down menu, and the size of administrative areas varies greatly
+ * between and within countries so it doesn't infer much about locality.
+ * <li>Extracting postal codes or sorting codes for address validation or external lookup. This
+ * only works for certain countries, such as the United Kingdom, where postal codes have a high
+ * resolution.
+ * </ul>
+ * <p>
+ * All values stored in this class are trimmed of ASCII whitespace. Setting an empty, or whitespace
+ * only field in the builder will clear it and result in a {@code null} being returned from the
+ * corresponding {@code AddressData} instance..
  */
-public class AddressData {
+public final class AddressData {
+  // The list of deprecated address fields which are superseded by STREET_ADDRESS.
+  @SuppressWarnings("deprecation")  // For legacy address fields.
+  private static final List<AddressField> ADDRESS_LINE_FIELDS = Collections.unmodifiableList(
+      Arrays.asList(AddressField.ADDRESS_LINE_1, AddressField.ADDRESS_LINE_2));
+
+  private static final int ADDRESS_LINE_COUNT = ADDRESS_LINE_FIELDS.size();
+
+  // The set of address fields for which a single string value can be mapped.
+  private static final EnumSet<AddressField> SINGLE_VALUE_FIELDS;
+  static {
+    SINGLE_VALUE_FIELDS = EnumSet.allOf(AddressField.class);
+    SINGLE_VALUE_FIELDS.removeAll(ADDRESS_LINE_FIELDS);
+    SINGLE_VALUE_FIELDS.remove(AddressField.STREET_ADDRESS);
+  }
+
+  // Detailed information on these fields is available in the javadoc for their respective getters.
+
   // CLDR (Common Locale Data Repository) country code.
-  // For example, "US" for United States.
-  // (Note: Use "GB", not "UK", for Great Britain)
   private final String postalCountry;
 
-  // street street, line 1
-  private final String addressLine1;
-
-  // street street, line 2
-  private final String addressLine2;
+  // The most specific part of any address. They may be left empty if more detailed fields are used
+  // instead, or they may be used in addition to these if the more detailed fields do not fulfill
+  // requirements, or they may be used instead of more detailed fields to represent the street-level
+  // part.
+  private final List<String> addressLines;
 
   // Top-level administrative subdivision of this country.
-  // Examples: US state, IT region, UK constituent nation, JP prefecture.
   private final String administrativeArea;
 
-  // Locality. A fuzzy term, but it generally refers to
-  // the city/town portion of an address.  In regions of the world where
-  // localities are not well defined or do not fit into this structure well
-  // (for example, Japan and China), leave locality empty and use
-  // addressLine1.
-  // Examples: US city, IT comune, UK post town.
+  // Generally refers to the city/town portion of an address.
   private final String locality;
 
-  // Dependent locality or sublocality.  Used for UK dependent localities,
-  // or neighborhoods or boroughs in other locations.  If trying to
-  // represent a UK double-dependent locality, include both the
-  // double-dependent locality and the dependent locality in this field,
-  // e.g. "Whaley, Langwith".
+  // Dependent locality or sublocality. Used for neighborhoods or suburbs.
   private final String dependentLocality;
 
-  // Postal Code. values are frequently alphanumeric.
-  // Examples: "94043", "94043-1351", "SW1W", "SW1W 9TQ".
+  // Values are frequently alphanumeric.
   private final String postalCode;
 
-  // Sorting code - use is very country-specific.
-  // This corresponds to the SortingCode sub-element of the xAL
-  // PostalServiceElements element.
-  // Examples: FR CEDEX.
+  // This corresponds to the SortingCode sub-element of the xAL PostalServiceElements element.
+  // Use is very country-specific.
   private final String sortingCode;
 
-  // The firm or organization. This goes at a finer granularity than
-  // address lines in the address. Omit if not needed.
+  // The firm or organization. This goes at a finer granularity than address lines in the address.
   private final String organization;
 
-  // The recipient. This goes at a finer granularity than address lines
-  // in the address. Not present in xAL. Omit if not needed.
+  // The recipient. This goes at a finer granularity than address lines in the address. Not present
+  // in xAL.
   private final String recipient;
 
-  // Language code of the address. Can be set to null. See its getter and setter
-  // for more information.
+  // BCP-47 language code for the address. Can be set to null.
   private final String languageCode;
 
-  /**
-   * Use {@link Builder} to create instances.
-   */
   private AddressData(Builder builder) {
-    postalCountry = builder.values.get(AddressField.COUNTRY);
-    administrativeArea = builder.values.get(AddressField.ADMIN_AREA);
-    locality = builder.values.get(AddressField.LOCALITY);
-    dependentLocality = builder.values.get(AddressField.DEPENDENT_LOCALITY);
-    postalCode = builder.values.get(AddressField.POSTAL_CODE);
-    sortingCode = builder.values.get(AddressField.SORTING_CODE);
-    organization = builder.values.get(AddressField.ORGANIZATION);
-    recipient = builder.values.get(AddressField.RECIPIENT);
-    addressLine1 = builder.values.get(AddressField.ADDRESS_LINE_1);
-    addressLine2 = builder.values.get(AddressField.ADDRESS_LINE_2);
-    languageCode = builder.language;
+    this.postalCountry = builder.fields.get(AddressField.COUNTRY);
+    this.administrativeArea = builder.fields.get(AddressField.ADMIN_AREA);
+    this.locality = builder.fields.get(AddressField.LOCALITY);
+    this.dependentLocality = builder.fields.get(AddressField.DEPENDENT_LOCALITY);
+    this.postalCode = builder.fields.get(AddressField.POSTAL_CODE);
+    this.sortingCode = builder.fields.get(AddressField.SORTING_CODE);
+    this.organization = builder.fields.get(AddressField.ORGANIZATION);
+    this.recipient = builder.fields.get(AddressField.RECIPIENT);
+    this.addressLines = Collections.unmodifiableList(
+        normalizeAddressLines(new ArrayList<String>(builder.addressLines)));
+    this.languageCode = builder.language;
+  }
+
+  // Helper to normalize a list of address lines. The input may contain null entries or strings
+  // which must be split into multiple lines. The resulting list entries will be trimmed
+  // consistently with String.trim() and any empty results are ignored.
+  // TODO: Trim entries properly with respect to Unicode whitespace.
+  private static List<String> normalizeAddressLines(List<String> lines) {
+    // Guava equivalent code for each line would look something like:
+    // Splitter.on("\n").trimResults(CharMatcher.inRange('\0', ' ')).omitEmptyStrings();
+    for (int index = 0; index < lines.size(); ) {
+      String line = lines.remove(index);
+      if (line == null) {
+        continue;
+      }
+      if (line.contains("\n")) {
+        for (String splitLine : line.split("\n")) {
+          index = maybeAddTrimmedLine(splitLine, lines, index);
+        }
+      } else {
+        index = maybeAddTrimmedLine(line, lines, index);
+      }
+    }
+    return lines;
+  }
+
+  // Helper to trim a string and (if not empty) add it to the given list at the specified index.
+  // Returns the new index at which any following elements should be added.
+  private static int maybeAddTrimmedLine(String line, List<String> lines, int index) {
+    line = Util.trimToNull(line);
+    if (line != null) {
+      lines.add(index++, line);
+    }
+    return index;
   }
 
   /**
-   * Returns the postal country.
-   *
-   * <p>The returned value is not user-presentable. For example, {@code getPostalCountry()} may
-   * return {@code "GB"}, while addresses in Great Britain should be displayed using "UK".
+   * Returns a string representation of the address, used for debugging.
+   */
+  @Override
+  public String toString() {
+    StringBuilder output = new StringBuilder("(AddressData: "
+        + "POSTAL_COUNTRY=" + postalCountry + "; "
+        + "LANGUAGE=" + languageCode + "; ");
+    for (String line : addressLines) {
+      output.append(line + "; ");
+    }
+    output.append("ADMIN_AREA=" + administrativeArea + "; "
+        + "LOCALITY=" + locality + "; "
+        + "DEPENDENT_LOCALITY=" + dependentLocality + "; "
+        + "POSTAL_CODE=" + postalCode + "; "
+        + "SORTING_CODE=" + sortingCode + "; "
+        + "ORGANIZATION=" + organization + "; "
+        + "RECIPIENT=" + recipient
+        + ")");
+    return output.toString();
+  }
+
+  /**
+   * Returns the CLDR region code for this address; note that this is <em>not</em> the same as the
+   * ISO 3166-1 2-letter country code. While technically optional, this field will always be set
+   * by the address widget when an address is entered or edited, and will be assumed to be set by
+   * many other tools.
+   * <p>
+   * While they have most of their values in common with the CLDR region codes, the ISO 2-letter
+   * country codes have one significant disadvantage; they are not stable and values can change over
+   * time. For example {@code "CS"} was originally used to represent Czechoslovakia, but later
+   * represented Serbia and Montenegro. In contrast, CLDR region codes are never reused and can
+   * represent more regions, such as Ascension Island (AC).
+   * <p>
+   * See the page on
+   * <a href="http://unicode.org/cldr/charts/26/supplemental/territory_containment_un_m_49.html">
+   * Territory Containment</a> for a list of CLDR region codes.
+   * <p>
+   * Note that the region codes not user-presentable; "GB" is Great Britain but this should always
+   * be displayed to a user as "UK" or "United Kingdom".
    */
   public String getPostalCountry() {
     return postalCountry;
   }
 
-  public String getAddressLine1() {
-    return addressLine1;
+  /**
+   * Returns multiple free-form address lines representing low level parts of an address,
+   * possibly empty. The first line represents the lowest level part of the address, other than
+   * recipient or organization.
+   * <p>
+   * Note that the number of lines returned by this method may be greater than the number of lines
+   * set on the original builder if some of the lines contained embedded newlines. The values
+   * returned by this method will never contain embedded newlines.
+   * <p>
+   * For example:
+   * <pre>{@code
+   *   data = AddressData.builder()
+   *       .setAddressLine1("First line\nSecond line")
+   *       .setAddressLine2("Last line")
+   *       .build();
+   *   // We end up with 3 lines in the final AddressData instance:
+   *   // data.getAddressLines() == [ "First line", "Second line", "Last line" ]
+   * }</pre>
+   */
+  public List<String> getAddressLines() {
+    return addressLines;
   }
 
+  /** @deprecated Use {@link #getAddressLines} in preference. */
+  @Deprecated
+  public String getAddressLine1() {
+    return getAddressLine(1);
+  }
+
+  /** @deprecated Use {@link #getAddressLines} in preference. */
+  @Deprecated
   public String getAddressLine2() {
-    return addressLine2;
+    return getAddressLine(2);
+  }
+
+  // Helper for returning the Nth address line. This is split out here so that it's easily to
+  // change the maximum number of address lines we support.
+  private String getAddressLine(int lineNumber) {
+    // If not the last available line, OR if we're the last line but there are no extra lines...
+    if (lineNumber < ADDRESS_LINE_COUNT || lineNumber >= addressLines.size()) {
+      return (lineNumber <= addressLines.size()) ? addressLines.get(lineNumber - 1) : null;
+    }
+    // We're asking for the last available line and there are additional lines in the data.
+    // Here it should be true that: lineNumber == ADDRESS_LINE_COUNT
+    // Guava equivalent:
+    // return Joiner.on(", ")
+    //     .join(addressLines.subList(ADDRESS_LINE_COUNT - 1, addressLines.size()));
+    StringBuilder joinedLastLine = new StringBuilder(addressLines.get(lineNumber - 1));
+    for (String line : addressLines.subList(lineNumber, addressLines.size())) {
+      joinedLastLine.append(", ").append(line);
+    }
+    return joinedLastLine.toString();
   }
 
   /**
    * Returns the top-level administrative subdivision of this country. Different postal countries
-   * use different names to refer to their administrative areas. For example, this is called
-   * "state" in the United States, "region" in Italy, "constituent nation" in Great Britain, or
-   * "prefecture" in Japan.
+   * use different names to refer to their administrative areas. For example: "state" (US), "region"
+   * (Italy) or "prefecture" (Japan).
+   * <p>
+   * Where data is available, the user will be able to select the administrative area name from a
+   * drop-down list, ensuring that it has only expected values. However this is not always possible
+   * and no strong assumptions about validity should be made by the user for this value.
    */
   public String getAdministrativeArea() {
     return administrativeArea;
   }
 
   /**
-   * Returns the locality. The usage of this field varies by region, but it generally refers to
-   * the "city" or "town" of the address. Some regions do not use this field; their address lines
-   * are sufficient to locate an address within a sub-administrative area. For example, this is
-   * called "city" in the United States, "comune" in Italy, or "post town" in Great Britain.
+   * Returns the language specific locality, if present. The usage of this field varies by region,
+   * but it generally refers to the "city" or "town" of the address. Some regions do not use this
+   * field; their address lines combined with things like postal code or administrative area are
+   * sufficient to locate an address.
+   * <p>
+   * Different countries use different names to refer to their localities. For example: "city" (US),
+   * "comune" (Italy) or "post town" (Great Britain). For Japan this would return the shikuchouson
+   * and sub-shikuchouson.
    */
   public String getLocality() {
     return locality;
   }
 
   /**
-   * Returns the dependent locality.
-   *
-   * <p>This is used for Great Britain dependent localities, or neighborhoods or boroughs in other
-   * locations.
-   *
-   * <p>In cases such as Great Britain, this field may contain a double-dependent locality, such
-   * as "Whaley, Langwith".
+   * Returns the dependent locality, if present.
+   * <p>
+   * This is used for neighborhoods and suburbs. Typically a dependent locality will represent a
+   * smaller geographical area than a locality, but need not be contained within it.
    */
   public String getDependentLocality() {
     return dependentLocality;
   }
 
   /**
-   * Returns the firm or organization.
-   */
-  public String getOrganization() {
-    return organization;
-  }
-
-  /**
-   * Returns the recipient. Examples: "Jesse Wilson" or "Jesse Wilson c/o Apurva Mathad".
-   */
-  public String getRecipient() {
-    return recipient;
-  }
-
-  /**
-   * Returns the country-specific postal code. Examples: "94043", "94043-1351", "SW1W",
-   * "SW1W 9TQ".
+   * Returns the postal code of the address, if present. This value is not language specific but
+   * may contain arbitrary formatting characters such as spaces or hyphens and might require
+   * normalization before any meaningful comparison of values.
+   * <p>
+   * For example: "94043", "94043-1351", "SW1W", "SW1W 9TQ".
    */
   public String getPostalCode() {
     return postalCode;
   }
 
   /**
-   * Returns the country-specific sorting code. For example, the
-   * <a href="http://en.wikipedia.org/wiki/List_of_postal_codes_in_France"> French CEDEX</a>
+   * Returns the sorting code if present. Sorting codes are distinct from postal codes and only
+   * used in a handful of regions (eg, France).
+   * <p>
+   * For example in France this field would contain a
+   * <a href="http://en.wikipedia.org/wiki/List_of_postal_codes_in_France">CEDEX</a> value.
    */
   public String getSortingCode() {
     return sortingCode;
   }
 
+  /**
+   * Returns the free form organization string, if present. No assumptions should be made about
+   * the contents of this field. This field exists because in some situations the organization
+   * and recipient fields must be treated specially during formatting. It is not a good idea to
+   * allow users to enter the organization or recipient in the street address lines as this will
+   * result in badly formatted and non-geocodeable addresses.
+   */
+  public String getOrganization() {
+    return organization;
+  }
+
+  /**
+   * Returns the free form recipient string, if present. No assumptions should be made about the
+   * contents of this field. This field exists because in some situations the organization
+   * and recipient fields must be treated specially during formatting. It is not a good idea to
+   * allow users to enter the organization or recipient in the street address lines as this will
+   * result in badly formatted and non-geocodeable addresses.
+   */
+  public String getRecipient() {
+    return recipient;
+  }
+
+  /**
+   * Returns a value for those address fields which map to a single string value.
+   * <p>
+   * Note that while it is possible to pass {@link AddressField#ADDRESS_LINE_1} and
+   * {@link AddressField#ADDRESS_LINE_2} into this method, these fields are deprecated and will be
+   * removed. In general you should be using named methods to obtain specific values for the address
+   * (eg, {@link #getAddressLines()}) and avoid iterating in a general way over the fields.
+   * This method has very little value outside of the widget itself and is scheduled for removal.
+   *
+   * @deprecated Do not use; scheduled for removal from the public API.
+   */
+  @Deprecated
+  @SuppressWarnings("deprecation")
+  // TODO: Move this to a utility method rather than exposing it in the public API.
   public String getFieldValue(AddressField field) {
     switch (field) {
       case COUNTRY:
@@ -219,21 +388,28 @@ public class AddressData {
       case SORTING_CODE:
         return sortingCode;
       case ADDRESS_LINE_1:
-        return addressLine1;
+        return getAddressLine1();
       case ADDRESS_LINE_2:
-        return addressLine2;
+        return getAddressLine2();
       case ORGANIZATION:
         return organization;
       case RECIPIENT:
         return recipient;
       default:
-        throw new IllegalArgumentException("unrecognized key: " + field);
+        throw new IllegalArgumentException("multi-value fields not supported: " + field);
     }
   }
 
   /**
-   * Returns the language of the text of this address. Languages are used to guide how the address
-   * is <a href="http://en.wikipedia.org/wiki/Mailing_address_format_by_country"> formatted for
+   * Returns the BCP-47 language code for this address which defines the language we expect to be
+   * used for any language specific fields. If this method returns {@code null} then the language
+   * is assumed to be in the default (most used) language for the region code of the address;
+   * although the precise determination of a default language is often approximate and may change
+   * over time. Wherever possible it is recommended to construct {@code AddressData} instances
+   * with a specific language code.
+   * <p>
+   * Languages are used to guide how the address is <a
+   * href="http://en.wikipedia.org/wiki/Mailing_address_format_by_country"> formatted for
    * display</a>. The same address may have different {@link AddressData} representations in
    * different languages. For example, the French name of "New Mexico" is "Nouveau-Mexique".
    */
@@ -241,58 +417,111 @@ public class AddressData {
     return languageCode;
   }
 
-  /**
-   * Builder for AddressData
-   */
-  public static class Builder {
+  /** Returns a new builder to construct an {@code AddressData} instance. */
+  public static Builder builder() {
+    return new Builder();
+  }
 
-    private final Map<AddressField, String> values;
+  /** Returns a new builder to construct an {@code AddressData} instance. */
+  public static Builder builder(AddressData address) {
+    return builder().set(address);
+  }
 
+  /** Builder for AddressData. */
+  public static final class Builder {
+    // A map of single value address fields to their values.
+    private final Map<AddressField, String> fields = new HashMap<AddressField, String>();
+    // The address lines, not normalized.
+    private final List<String> addressLines = new ArrayList<String>();
+    // The BCP-47 language of the address.
     private String language = null;
 
-    public Builder() {
-      values = new HashMap<AddressField, String>();
-    }
-
     /**
-     * A constructor that sets address field with input data. Street fields will be normalized
-     * in the process. I.e., after copy, there will not be any empty street line in front of
-     * non-empty ones. For example, if input data's street line 1 is null but street line 2
-     * has a value, this method will copy street line 2's value and set it to street line 1.
+     * Constructs an empty builder for AddressData instances. Prefer to use one of the
+     * {@link AddressData#builder} methods in preference to this.
      */
-    public Builder(AddressData addr) {
-      values = new HashMap<AddressField, String>();
-      set(addr);
-    }
+    // TODO: Migrate users and make this private.
+    public Builder() {}
 
-    public Builder setCountry(String value) {
-      return set(AddressField.COUNTRY, value);
-    }
-
-    public Builder setAdminArea(String value) {
-      return set(AddressField.ADMIN_AREA, value);
-    }
-
-    public Builder setLocality(String value) {
-      return set(AddressField.LOCALITY, value);
-    }
-
-    public Builder setDependentLocality(String value) {
-      return set(AddressField.DEPENDENT_LOCALITY, value);
-    }
-
-    public Builder setPostalCode(String value) {
-      return set(AddressField.POSTAL_CODE, value);
-    }
-
-    public Builder setSortingCode(String value) {
-      return set(AddressField.SORTING_CODE, value);
+    /**
+     * Constructs a builder for AddressData instances using data from the given address.
+     * Prefer to use one of the {@link AddressData#builder} methods in preference to this.
+     *
+     * @deprecated Use the builder() methods on AddressData in preference to this.
+     */
+    @Deprecated
+    // TODO: Migrate users and delete this method.
+    public Builder(AddressData address) {
+      set(address);
     }
 
     /**
-     * Sets the language code.
+     * Sets the 2-letter CLDR region code of the address; see
+     * {@link AddressData#getPostalCountry()}. Unlike other values passed to the builder, the
+     * region code can never be null.
      *
-     * @param languageCode the language to use, or {@code null} for no specified language.
+     * @param regionCode the CLDR region code of the address.
+     */
+    // TODO: Rename to setRegionCode.
+    public Builder setCountry(String regionCode) {
+      return set(AddressField.COUNTRY, checkNotNull(regionCode));
+    }
+
+    /**
+     * Sets or clears the administrative area of the address; see
+     * {@link AddressData#getAdministrativeArea()}.
+     *
+     * @param adminAreaName the administrative area name, or null to clear an existing value.
+     */
+    // TODO: Rename to setAdministrativeArea.
+    public Builder setAdminArea(String adminAreaName) {
+      return set(AddressField.ADMIN_AREA, adminAreaName);
+    }
+
+    /**
+     * Sets or clears the locality of the address; see {@link AddressData#getLocality()}.
+     *
+     * @param locality the locality name, or null to clear an existing value.
+     */
+    public Builder setLocality(String locality) {
+      return set(AddressField.LOCALITY, locality);
+    }
+
+    /**
+     * Sets or clears the dependent locality of the address; see
+     * {@link AddressData#getDependentLocality()}.
+     *
+     * @param dependentLocality the dependent locality name, or null to clear an existing value.
+     */
+    public Builder setDependentLocality(String dependentLocality) {
+      return set(AddressField.DEPENDENT_LOCALITY, dependentLocality);
+    }
+
+    /**
+     * Sets or clears the postal code of the address; see {@link AddressData#getPostalCode()}.
+     *
+     * @param postalCode the postal code, or null to clear an existing value.
+     */
+    public Builder setPostalCode(String postalCode) {
+      return set(AddressField.POSTAL_CODE, postalCode);
+    }
+
+    /**
+     * Sets or clears the sorting code of the address; see {@link AddressData#getSortingCode()}.
+     *
+     * @param sortingCode the sorting code, or null to clear an existing value.
+     */
+    public Builder setSortingCode(String sortingCode) {
+      return set(AddressField.SORTING_CODE, sortingCode);
+    }
+
+    /**
+     * Sets or clears the BCP-47 language code for this address (eg, "en" or "zh-Hant"). If the
+     * language is not set, then the address will be assumed to be in the default language of the
+     * country of the address; however it is highly discouraged to rely on this as the default
+     * language may change over time. See {@link AddressData#getLanguageCode()}.
+     *
+     * @param languageCode the BCP-47 language code, or null to clear an existing value.
      */
     public Builder setLanguageCode(String languageCode) {
       this.language = languageCode;
@@ -300,95 +529,175 @@ public class AddressData {
     }
 
     /**
-     * Sets address lines 1 and 2 (if necessary) from a string that may contain multiple lines.
-     *
-     * <p> Example: Input "  \n   \n1600 Amphitheatre Ave\n\nRoom 122" will set the following
-     * values:<br/> line 1: 1600 Amphitheatre Ave<br/> line 2: Room 122<br/> </p>
-     *
-     * @param value a street string
+     * Sets multiple unstructured street level lines in the address. Calling this method will
+     * always discard any existing address lines before adding new ones.
+     * <p>
+     * Note that the number of lines set by this method is preserved in the builder's state but a
+     * single line set here may result in multiple lines in the resulting {@code AddressData}
+     * instance if it contains embedded newline characters.
+     * <p>
+     * For example:
+     * <pre>{@code
+     *   data = AddressData.builder()
+     *       .setAddressLines(Arrays.asList("First line\nSecond line"))
+     *       .setAddressLine2("Last line");
+     *       .build();
+     *   // data.getAddressLines() == [ "First line", "Second line", "Last line" ]
+     * }</pre>
      */
-    public Builder setAddress(String value) {
-      setAddressLine1(value);
+    public Builder setAddressLines(Iterable<String> lines) {
+      addressLines.clear();
+      for (String line : lines) {
+        addressLines.add(line);
+      }
       return this;
     }
 
     /**
-     * Sets address by copying from input address data. Street fields will be normalized in the
-     * process. I.e., after copy, there will not be any empty street lines in front of non-empty
-     * ones. For example, if input data's street line 1 is null but street line 2 has a value,
-     * this method will copy street line 2's value and set it to street line 1.
+     * Sets multiple street lines from a single street string, clearing any existing address lines
+     * first. The input string may contain new lines which will result in multiple separate lines
+     * in the resulting {@code AddressData} instance. After splitting, each line is trimmed and
+     * empty lines are ignored.
+     * <p>
+     * Example: {@code "  \n   \n1600 Amphitheatre Ave\n\nRoom 122"} will set the lines:
+     * <ol>
+     * <li>"1600 Amphitheatre Ave"
+     * <li>"Room 122"
+     * </ol>
+     *
+     * @param value a string containing one or more address lines, separated by {@code "\n"}.
+     */
+    public Builder setAddress(String value) {
+      addressLines.clear();
+      addressLines.add(value);
+      normalizeAddressLines(addressLines);
+      return this;
+    }
+
+    /**
+     * Copies all the data of the given address into the builder. Any existing data in the builder
+     * is discarded.
      */
     public Builder set(AddressData data) {
-      values.clear();
-      for (AddressField addressField : AddressField.values()) {
-        if (addressField == AddressField.STREET_ADDRESS) {
-            continue;  // Do nothing.
-        } else {
-          set(addressField, data.getFieldValue(addressField));
-        }
+      fields.clear();
+      for (AddressField addressField : SINGLE_VALUE_FIELDS) {
+        set(addressField, data.getFieldValue(addressField));
       }
-      normalizeAddresses();
+      addressLines.clear();
+      addressLines.addAll(data.addressLines);
       setLanguageCode(data.getLanguageCode());
       return this;
     }
 
+    /**
+     * TODO: Remove this method in favor of setAddressLines(Iterable<String>).
+     *
+     * @deprecated Use {@link #setAddressLines} instead.
+     */
+    @Deprecated
     public Builder setAddressLine1(String value) {
-      return set(AddressField.ADDRESS_LINE_1, value);
-    }
-
-    public Builder setAddressLine2(String value) {
-      return set(AddressField.ADDRESS_LINE_2, value);
-    }
-
-    public Builder setOrganization(String value) {
-      return set(AddressField.ORGANIZATION, value);
-    }
-
-    public Builder setRecipient(String value) {
-      return set(AddressField.RECIPIENT, value);
+      return setAddressLine(1, value);
     }
 
     /**
-     * Sets an address field with the specified value. If the value is empty (a null string,
-     * empty string, or a string that contains only spaces), the original value associated with
-     * the field will be removed.
+     * TODO: Remove this method in favor of setAddressLines(Iterable<String>).
+     *
+     * @deprecated Use {@link #setAddressLines} instead.
      */
+    @Deprecated
+    public Builder setAddressLine2(String value) {
+      return setAddressLine(2, value);
+    }
+
+    /**
+     * Sets or clears the organization of the address; see {@link AddressData#getOrganization()}.
+     *
+     * @param organization the organization, or null to clear an existing value.
+     */
+    public Builder setOrganization(String organization) {
+      return set(AddressField.ORGANIZATION, organization);
+    }
+
+    /**
+     * Sets or clears the recipient of the address; see {@link AddressData#getRecipient()}.
+     *
+     * @param recipient the recipient, or null to clear an existing value.
+     */
+    public Builder setRecipient(String recipient) {
+      return set(AddressField.RECIPIENT, recipient);
+    }
+
+    /**
+     * Sets an address field with the specified value. If the value is empty (null or whitespace),
+     * the original value associated with the field will be removed.
+     *
+     * @deprecated Do not use; scheduled for removal from the public API.
+     */
+    @Deprecated
+    @SuppressWarnings("deprecation")
+    // TODO: Reimplement using public API as a utility function in AddressWidget (the only caller).
     public Builder set(AddressField field, String value) {
-      if (value == null || value.length() == 0) {
-        values.remove(field);
+      if (SINGLE_VALUE_FIELDS.contains(field)) {
+        value = Util.trimToNull(value);
+        if (value == null) {
+          fields.remove(field);
+        } else {
+          fields.put(field, value);
+        }
+      } else if (field == AddressField.STREET_ADDRESS) {
+        if (value == null) {
+          addressLines.clear();
+        } else {
+          setAddress(value);
+        }
       } else {
-        values.put(field, value.trim());
+        int lineNum = ADDRESS_LINE_FIELDS.indexOf(field) + 1;
+        if (lineNum > 0) {
+          setAddressLine(lineNum, value);
+        }
       }
-      normalizeAddresses();
       return this;
     }
 
-    public AddressData build() {
-      return new AddressData(this);
+    // This may preserve whitespace at the ends of lines, but this gets normalized when we build
+    // the data instance.
+    private Builder setAddressLine(int lineNum, String value) {
+      if (Util.trimToNull(value) == null) {
+        if (lineNum < addressLines.size()) {
+          // Clearing an element that isn't the last in the list.
+          addressLines.set(lineNum - 1, null);
+        } else if (lineNum == addressLines.size()) {
+          // Clearing the last element (remove it and clear up trailing nulls).
+          addressLines.remove(lineNum - 1);
+          for (int i = addressLines.size() - 1; i >= 0 && addressLines.get(i) == null; i--) {
+            addressLines.remove(i);
+          }
+        }
+      } else {
+        // Padding the list with nulls if necessary.
+        for (int i = addressLines.size(); i < lineNum; i++) {
+          addressLines.add(null);
+        }
+        // Set the non-null value.
+        addressLines.set(lineNum - 1, value);
+      }
+      return this;
     }
 
     /**
-     * Parses content of address line fields.
-     * If address_line_1 is empty, address_line_2 will be used to populate address_line_1 if
-     * possible. If address_line_1 contains a new line, content after the new line will be
-     * saved in address_line_2.
+     * Builds an AddressData instance from the current state of the builder. A builder instance may
+     * be used to build multiple data instances.
+     * <p>
+     * During building the street address line information is normalized and the following will be
+     * true for any build instance.
+     * <ol>
+     * <li>The order of address lines is retained relative to the builder.
+     * <li>Empty address lines (empty strings, whitespace only or null) are removed.
+     * <li>Remaining address lines are trimmed of whitespace.
+     * </ol>
      */
-    private void normalizeAddresses() {
-      String address1 = values.get(AddressField.ADDRESS_LINE_1);
-      String address2 = values.get(AddressField.ADDRESS_LINE_2);
-      if (address1 == null || address1.trim().length() == 0) {
-        address1 = address2;
-        address2 = null;
-      }
-      if (address1 != null) {
-        String[] addressLines = address1.split("\n");
-        if (addressLines.length > 1) {
-          address1 = addressLines[0];
-          address2 = addressLines[1];
-        }
-      }
-      values.put(AddressField.ADDRESS_LINE_1, address1);
-      values.put(AddressField.ADDRESS_LINE_2, address2);
+    public AddressData build() {
+      return new AddressData(this);
     }
   }
 }

--- a/java/src/com/android/i18n/addressinput/AddressDataKey.java
+++ b/java/src/com/android/i18n/addressinput/AddressDataKey.java
@@ -24,103 +24,102 @@ import java.util.Map;
  * the Android Address Input Widget.
  */
 enum AddressDataKey {
-    /**
-     * Identifies the countries for which data is provided.
-     */
-    COUNTRIES,
-    /**
-     * The standard format string.  This identifies which fields can be used in the address, along
-     * with their order.  This also carries additional information for use in formatting the fields
-     * into multiple lines. This is also used to indicate which fields should _not_ be used for an
-     * address.
-     */
-    FMT,
-    /**
-     * The unique ID of the region, in the form of a path from parent IDs to the key.
-     */
-    ID,
-    /**
-     * The key of the region, unique to its parent. If there is an accepted abbreviation for this
-     * region, then the key will be set to this and name will be set to the local name for this
-     * region. If there is no accepted abbreviation, then this key will be the local name and there
-     * will be no local name specified. This value must be present.
-     */
-    KEY,
-    /**
-     * The default language of any data for this region, if known.
-     */
-    LANG,
-    /**
-     * The languages used by any data for this region, if known.
-     */
-    LANGUAGES,
-    /**
-     * The latin format string {@link #FMT} used when a country defines an alternative format for
-     * use with the latin script, such as in China.
-     */
-    LFMT,
-    /**
-     * Indicates the type of the name used for the locality (city) field.
-     */
-    LOCALITY_NAME_TYPE,
-    /**
-     * Indicates which fields must be present in a valid address.
-     */
-    REQUIRE,
-    /**
-     * Indicates the type of the name used for the state (administrative area) field.
-     */
-    STATE_NAME_TYPE,
-    /**
-     * Encodes the {@link #KEY} value of all the children of this region.
-     */
-    SUB_KEYS,
-    /**
-     * Encodes the transliterated latin name value of all the children of this region, if the local
-     * names are not in latin script already.
-     */
-    SUB_LNAMES,
-    /**
-     * Indicates the type of the name used for the sublocality field.
-     */
-    SUBLOCALITY_NAME_TYPE,
-    /**
-     * Indicates, for each child of this region, whether that child has additional children.
-     */
-    SUB_MORES,
-    /**
-     * Encodes the local name value of all the children of this region.
-     */
-    SUB_NAMES,
-    /**
-     * Encodes the {@link #ZIP} value for the subtree beneath this region.
-     */
-    XZIP,
-    /**
-     * Encodes the postal code pattern if at the country level, and the postal code prefix if at a
-     * level below country.
-     */
-    ZIP,
-    /**
-     * Indicates the type of the name used for the ZIP (postal code) field.
-     */
-    ZIP_NAME_TYPE;
+  /**
+   * Identifies the countries for which data is provided.
+   */
+  COUNTRIES,
+  /**
+   * The standard format string. This identifies which fields can be used in the address, along with
+   * their order. This also carries additional information for use in formatting the fields into
+   * multiple lines. This is also used to indicate which fields should _not_ be used for an address.
+   */
+  FMT,
+  /**
+   * The unique ID of the region, in the form of a path from parent IDs to the key.
+   */
+  ID,
+  /**
+   * The key of the region, unique to its parent. If there is an accepted abbreviation for this
+   * region, then the key will be set to this and name will be set to the local name for this
+   * region. If there is no accepted abbreviation, then this key will be the local name and there
+   * will be no local name specified. This value must be present.
+   */
+  KEY,
+  /**
+   * The default language of any data for this region, if known.
+   */
+  LANG,
+  /**
+   * The languages used by any data for this region, if known.
+   */
+  LANGUAGES,
+  /**
+   * The latin format string {@link #FMT} used when a country defines an alternative format for
+   * use with the latin script, such as in China.
+   */
+  LFMT,
+  /**
+   * Indicates the type of the name used for the locality (city) field.
+   */
+  LOCALITY_NAME_TYPE,
+  /**
+   * Indicates which fields must be present in a valid address.
+   */
+  REQUIRE,
+  /**
+   * Indicates the type of the name used for the state (administrative area) field.
+   */
+  STATE_NAME_TYPE,
+  /**
+   * Indicates the type of the name used for the sublocality field.
+   */
+  SUBLOCALITY_NAME_TYPE,
+  /**
+   * Encodes the {@link #KEY} value of all the children of this region.
+   */
+  SUB_KEYS,
+  /**
+   * Encodes the transliterated latin name value of all the children of this region, if the local
+   * names are not in latin script already.
+   */
+  SUB_LNAMES,
+  /**
+   * Indicates, for each child of this region, whether that child has additional children.
+   */
+  SUB_MORES,
+  /**
+   * Encodes the local name value of all the children of this region.
+   */
+  SUB_NAMES,
+  /**
+   * Encodes the {@link #ZIP} value for the subtree beneath this region.
+   */
+  XZIP,
+  /**
+   * Encodes the postal code pattern if at the country level, and the postal code prefix if at a
+   * level below country.
+   */
+  ZIP,
+  /**
+   * Indicates the type of the name used for the ZIP (postal code) field.
+   */
+  ZIP_NAME_TYPE;
 
-    /**
-     * Returns a field based on its keyname (value in the JSON-format file), or null if no field
-     * matches.
-     */
-    static AddressDataKey get(String keyname) {
-        return ADDRESS_KEY_NAME_MAP.get(keyname.toLowerCase());
+  /**
+   * Returns a field based on its keyname (value in the JSON-format file), or null if no field
+   * matches.
+   */
+  static AddressDataKey get(String keyname) {
+    return ADDRESS_KEY_NAME_MAP.get(keyname.toLowerCase());
+  }
+
+  private static final Map<String, AddressDataKey> ADDRESS_KEY_NAME_MAP =
+      new HashMap<String, AddressDataKey>();
+
+  static {
+    // Populates the map of enums against their lower-cased string values for easy look-up.
+    for (AddressDataKey field : values()) {
+      ADDRESS_KEY_NAME_MAP.put(field.toString().toLowerCase(), field);
     }
-
-    private static final Map<String, AddressDataKey> ADDRESS_KEY_NAME_MAP =
-        new HashMap<String, AddressDataKey>();
-
-    static {
-        // Populates the map of enums against their lower-cased string values for easy look-up.
-        for (AddressDataKey field : values()) {
-            ADDRESS_KEY_NAME_MAP.put(field.toString().toLowerCase(), field);
-        }
-    }
+  }
 }

--- a/java/src/com/android/i18n/addressinput/AddressProblemType.java
+++ b/java/src/com/android/i18n/addressinput/AddressProblemType.java
@@ -20,18 +20,19 @@ package com.android.i18n.addressinput;
  * Enumerates problems that default address verification can report.
  */
 public enum AddressProblemType {
-
   /**
-   * The field is not null and not whitespace, and the field should not be used for this country.
-   *
-   * <p>For example, in the U.S. the SORTING_CODE field is unused, so its presence is an error.
+   * The field is not null and not whitespace, and the field should not be used by addresses in this
+   * country.
+   * <p>
+   * For example, in the U.S. the SORTING_CODE field is unused, so its presence is an
+   * error. This cannot happen when using the Address Widget to enter an address.
    */
-  USING_UNUSED_FIELD,
+  UNEXPECTED_FIELD,
 
   /**
-   * The field is null or whitespace, and the field is required.
-   *
-   * <p>For example, in the U.S. ADMIN_AREA is a required field.
+   * The field is null or whitespace, and the field is required for addresses in this country.
+   * <p>
+   * For example, in the U.S. ADMIN_AREA is a required field.
    */
   MISSING_REQUIRED_FIELD,
 
@@ -46,18 +47,20 @@ public enum AddressProblemType {
 
   /**
    * A format for the field is defined and the value does not match. This is used to match
-   * POSTAL_CODE against the the format pattern generally.
-   *
-   * <p>For example, in the U.S. postal codes are five digits with an optional hyphen followed by
+   * POSTAL_CODE against the general format pattern. Formats indicate how many digits/letters should
+   * be present, and what punctuation is allowed.
+   * <p>
+   * For example, in the U.S. postal codes are five digits with an optional hyphen followed by
    * four digits.
    */
-  UNRECOGNIZED_FORMAT,
+  INVALID_FORMAT,
 
   /**
-   * A pattern for the field is defined and the value does not match. This is used to match
-   * POSTAL_CODE against a regular expression.
-   *
-   * <p>For example, in the U.S. postal codes in the state of California start with '9'.
+   * A specific pattern for the field is defined and the value does not match. This is used to match
+   * example) and the value does not match. This is used to match POSTAL_CODE against a regular
+   * expression.
+   * <p>
+   * For example, in the US postal codes in the state of California start with a '9'.
    */
   MISMATCHING_VALUE;
 

--- a/java/src/com/android/i18n/addressinput/AddressProblems.java
+++ b/java/src/com/android/i18n/addressinput/AddressProblems.java
@@ -28,8 +28,8 @@ public class AddressProblems {
       new HashMap<AddressField, AddressProblemType>();
 
   /**
-   * Only one address problem type is saved per addressField. Address field as used here refers to
-   * the different data parts in the AddressData class.
+   * Adds a problem of the given type for the given address field. Only one address problem is
+   * saved per address field.
    */
   void add(AddressField addressField, AddressProblemType problem) {
     problems.put(addressField, problem);

--- a/java/src/com/android/i18n/addressinput/AddressVerificationNodeData.java
+++ b/java/src/com/android/i18n/addressinput/AddressVerificationNodeData.java
@@ -26,8 +26,7 @@ import java.util.Map;
  * as a single string using '~' to separate the elements of the array, depending on the
  * AddressDataKey.
  */
-public class AddressVerificationNodeData {
-
+public final class AddressVerificationNodeData {
   private final Map<AddressDataKey, String> map;
 
   public AddressVerificationNodeData(Map<AddressDataKey, String> map) {

--- a/java/src/com/android/i18n/addressinput/AddressWidget.java
+++ b/java/src/com/android/i18n/addressinput/AddressWidget.java
@@ -214,7 +214,7 @@ public class AddressWidget implements AdapterView.OnItemSelectedListener {
 
   /** TODO: Add region-dependent width types for address fields. */
   private WidthType getFieldWidthType(AddressUiComponent field) {
-    return field.getId().getDefaulWidthType();
+    return field.getId().getDefaultWidthType();
   }
 
   private void createView(ViewGroup rootView, AddressUiComponent field, String defaultKey,
@@ -728,7 +728,7 @@ public class AddressWidget implements AdapterView.OnItemSelectedListener {
       case UNKNOWN_VALUE:
         String currentValue = address.getFieldValue(field);
         return String.format(context.getString(R.string.unknown_entry), currentValue);
-      case UNRECOGNIZED_FORMAT:
+      case INVALID_FORMAT:
         // We only support this error type for the Postal Code field.
         return (zipLabel == ZipLabel.POSTAL
             ? context.getString(R.string.unrecognized_format_postal_code)

--- a/java/src/com/android/i18n/addressinput/ClientCacheManager.java
+++ b/java/src/com/android/i18n/addressinput/ClientCacheManager.java
@@ -17,13 +17,13 @@
 package com.android.i18n.addressinput;
 
 /**
- *  Used by AddressWidget to handle caching in client-specific ways.
+ * Used by AddressWidget to handle caching in client-specific ways.
  */
 public interface ClientCacheManager {
   /** Get the data that is cached for the given key. */
   public String get(String key);
   /** Put the data for the given key into the cache. */
   public void put(String key, String data);
-  /** Get the Url of the server that serves address metadata. */
+  /** Get the URL of the server that serves address metadata. */
   public String getAddressServerUrl();
 }

--- a/java/src/com/android/i18n/addressinput/DataSource.java
+++ b/java/src/com/android/i18n/addressinput/DataSource.java
@@ -20,6 +20,17 @@ package com.android.i18n.addressinput;
 // removed when we have created code for static loading of data without using the
 // AddressVerificationData class.
 public interface DataSource {
+  /**
+   * Returns the default JSON data for the given key string (this method should complete immediately
+   * and must not trigger any network requests.
+   */
   AddressVerificationNodeData getDefaultData(String key);
+
+  /**
+   * A <b>blocking</b> method to return the JSON data for the given key string. This method will
+   * block the current thread until data is available or until a timeout occurs (at which point the
+   * default data will be returned). All networking and failure states are hidden from the caller by
+   * this API.
+   */
   AddressVerificationNodeData get(String key);
 }

--- a/java/src/com/android/i18n/addressinput/FormOptions.java
+++ b/java/src/com/android/i18n/addressinput/FormOptions.java
@@ -16,34 +16,36 @@
 
 package com.android.i18n.addressinput;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Configuration Options that can be used by Address Display components for things like show/hide
- * fields or make them readonly. By default, all the fields are visible and editable.
- *
- * <p>Also, provides the ability to add additional required fields, for e.g. {@link
+ * Configuration options for the address input widget used to control the visibility and interaction
+ * of specific fields to suit specific use cases (eg, collecting business addresses, collecting
+ * addresses for credit card verification etc...).
+ * <p>
+ * Also, provides the ability to add additional required fields, for e.g. {@link
  * AddressField#RECIPIENT}.
  */
-public class FormOptions {
+public final class FormOptions {
 
-  private final String baseId;
-
+  // These fields must never be null).
   private final EnumSet<AddressField> hiddenFields;
-
   private final EnumSet<AddressField> readonlyFields;
 
-  private final EnumSet<AddressField> requiredFields;
+  // Key is ISO 2-letter region code.
+  private Map<String, List<AddressField>> customFieldOrder =
+      new HashMap<String, List<AddressField>>();
 
   private final EnumMap<AddressField, String> customLabels =
       new EnumMap<AddressField, String>(AddressField.class);
 
-  private final Map<String, AddressField[]> overrideFieldOrder =
-      new HashMap<String, AddressField[]>();
+  private final EnumSet<AddressField> requiredFields;
 
   private final EnumMap<AddressField, Integer> maxLengths =
       new EnumMap<AddressField, Integer>(AddressField.class);
@@ -52,22 +54,15 @@ public class FormOptions {
 
   private FormOptions(Builder builder) {
     // copy values from builder
-    baseId = builder.baseId;
     hiddenFields = EnumSet.copyOf(builder.hiddenFields);
     readonlyFields = EnumSet.copyOf(builder.readonlyFields);
     requiredFields = EnumSet.copyOf(builder.requiredFields);
     customLabels.putAll(builder.customLabels);
-    overrideFieldOrder.putAll(builder.overrideFieldOrder);
+    customFieldOrder.putAll(builder.customFieldOrder);
     maxLengths.putAll(builder.maxLengths);
     serverUrl = builder.serverUrl;
   }
 
-  /**
-   * Gets base ID of the address form. Default is "addressform".
-   */
-  String getBaseId() {
-    return baseId;
-  }
 
   boolean isHidden(AddressField field) {
     return hiddenFields.contains(field);
@@ -103,17 +98,14 @@ public class FormOptions {
    * Gets the overridden field orders with their corresponding region code. Returns null if field
    * orders for {@code regionCode} is not specified.
    */
-  AddressField[] getCustomFieldOrder(String regionCode) {
-    if (regionCode == null) {
-      throw new RuntimeException("regionCode cannot be null.");
-    }
-    return overrideFieldOrder.get(regionCode);
+  List<AddressField> getCustomFieldOrder(String regionCode) {
+    return customFieldOrder.get(regionCode);
   }
 
   /**
    * Gets the customized max length for the {@code field}, or null if none.
    */
-  Integer getCustomMaxLength(AddressField field) {
+  int getCustomMaxLength(AddressField field) {
     return maxLengths.get(field);
   }
 
@@ -121,8 +113,6 @@ public class FormOptions {
    * Class to build the form, specifying the attributes for each field.
    */
   public static class Builder {
-
-    private String baseId = "addressform";
 
     private final EnumSet<AddressField> requiredFields =
         EnumSet.noneOf(AddressField.class);
@@ -136,8 +126,8 @@ public class FormOptions {
     private final EnumMap<AddressField, String> customLabels =
         new EnumMap<AddressField, String>(AddressField.class);
 
-    private final Map<String, AddressField[]> overrideFieldOrder =
-        new HashMap<String, AddressField[]>();
+    private final Map<String, List<AddressField>> customFieldOrder =
+        new HashMap<String, List<AddressField>>();
 
     private final EnumMap<AddressField, Integer> maxLengths =
         new EnumMap<AddressField, Integer>(AddressField.class);
@@ -146,17 +136,6 @@ public class FormOptions {
      * Uses the default server URL from CacheData.
      */
     private String serverUrl = new CacheData().getUrl();
-
-    /**
-     * Sets the base ID of the address form.
-     */
-    public Builder baseId(String baseId) {
-      if (baseId == null) {
-        throw new RuntimeException("baseId cannot be null.");
-      }
-      this.baseId = baseId;
-      return this;
-    }
 
     public Builder hide(AddressField field) {
       if (field == null) {
@@ -203,57 +182,49 @@ public class FormOptions {
     }
 
     /**
-     * Sets the field order for a region code. The order you set here will override the
-     * predefined one. For example, you can set field order for US to be first {@code
-     * AddressField#ORGANIZATION} then {@code AddressField#RECIPIENT}. Repeated address fields
-     * in {@code fields} are not allowed. Size of {@code fields} has to be larger than one.
-     * Input {@code fields} can be partial or even contain field not needed in the specified
-     * {@code regionCode}. For example, German addresses contain the following fields
-     * (in order):<br/>
-     {@link AddressField#RECIPIENT}, {@link AddressField#ORGANIZATION}, {@link
-     * AddressField#STREET_ADDRESS}, {@link AddressField#POSTAL_CODE}, {@link
-     * AddressField#LOCALITY}. <br/>
-     *
-     * <p>With the following call: <br/>
-     *
-     * customizeFieldOrder("DE", AddressField.ORGANIZATION, AddressField.RECIPIENT,
-     * AddressField.ADMIN_AREA);
-     *
-     * <p>Field order for Germany will become: <br/> {@link AddressField#ORGANIZATION}, {@link
-     * AddressField#RECIPIENT}, {@link AddressField#STREET_ADDRESS}, {@link
-     * AddressField#POSTAL_CODE}, {@link AddressField#LOCALITY}. </p>
-     *
-     * <p>Notice that:<br/> <ol> <li>{@link AddressField#ORGANIZATION} comes before {@link
-     * AddressField#RECIPIENT} after reordering.</li>
-     * <li>Fields not specified stays the same.</li>
-     * <li>{@link AddressField#ADMIN_AREA} is specified but since it is not in German address
-     * format, it is simpled neglected.</li> </ol>
-     *
-     * @param fields the overridden field order.
+     * Sets the order of address input fields for the given ISO 3166-1 two letter country code.
+     * <p>
+     * Input fields affected by custom ordering will be shown in the widget in the order they are
+     * given to this method (for the associated region code). Fields which are visible for a region,
+     * but which are not specified here, will appear in their original position in the form. For
+     * example, if a region defines the following fields:
+     * <pre>
+     * [ RECIPIENT -> ORGANIZATION -> STREET_ADDRESS -> LOCALITY -> ADMIN_AREA -> COUNTRY ]
+     * </pre>
+     * and the custom ordering for that region is (somewhat contrived):
+     * <pre>
+     * [ ORGANIZATION -> COUNTRY -> RECIPIENT ]
+     * </pre>
+     * Then the visible order of the input fields will be:
+     * <pre>
+     * [ ORGANIZATION -> COUNTRY -> STREET_ADDRESS -> LOCALITY -> ADMIN_AREA -> RECIPIENT ]
+     * </pre>
+     * <ul>
+     * <li>Fields not specified in the custom ordering (STREET_ADDRESS, LOCALITY, ADMIN_AREA)
+     * remain in their original, absolute, positions.
+     * <li>Custom ordered fields are re-positioned such that their relative order is now as
+     * specified (but other, non custom-ordered, fields can appear between them).
+     * </ul>
+     * <p>
+     * If the custom order contains a field which is not present for the specified region, it is
+     * silently ignored. Setting a custom ordering can never be used as a way to add fields for a
+     * region.
+     * <p>
+     * Typically this feature is used to reverse things like RECIPIENT and ORGANIZATION for certain
+     * business related use cases. It should not be used to "correct" perceived bad field ordering
+     * or make different countries "more consistent with each other".
      */
     public Builder customizeFieldOrder(String regionCode, AddressField... fields) {
-      if (regionCode == null) {
-        throw new RuntimeException("regionCode cannot be null.");
-      }
-      if (fields == null) {
-        throw new RuntimeException("Fields cannot be null.");
-      }
-      if (fields.length <= 1) {
-        throw new RuntimeException("There must be more than one field.");
-      }
-      HashSet<AddressField> checkList = new HashSet<AddressField>();
-      AddressField[] f = new AddressField[fields.length];
-      int i = 0;
-      for (AddressField field : fields) {
-        // Can't contain repeated address fields.
-        if (checkList.contains(field)) {
-          throw new RuntimeException("Address fields cannot be repeated.");
+      // TODO: Consider checking the given region code for validity against RegionDataConstants.
+      List<AddressField> fieldList = Collections.unmodifiableList(Arrays.asList(fields));
+      if (fieldList.size() > 0) {
+        if (EnumSet.copyOf(fieldList).size() != fieldList.size()) {
+          throw new IllegalArgumentException("duplicate address field: " + fieldList);
         }
-        checkList.add(field);
-        f[i] = field;
-        i++;
+        customFieldOrder.put(regionCode, fieldList);
+      } else {
+        customFieldOrder.remove(regionCode);
       }
-      overrideFieldOrder.put(regionCode, f);
       return this;
     }
 

--- a/java/src/com/android/i18n/addressinput/JsoMap.java
+++ b/java/src/com/android/i18n/addressinput/JsoMap.java
@@ -27,8 +27,7 @@ import java.util.Iterator;
 /**
  * Compatibility methods on top of the JSON data.
  */
-class JsoMap extends JSONObject {
-
+final class JsoMap extends JSONObject {
   /**
    * Construct a JsoMap object given some json text. This method directly evaluates the String
    * that you pass in; no error or safety checking is performed, so be very careful about the
@@ -81,7 +80,7 @@ class JsoMap extends JSONObject {
    * @throws ClassCastException, IllegalArgumentException.
    */
   @Override
-  public String get(String key) {  // throws ClassCastException, IllegalArgumentException
+  public String get(String key) {
     try {
       Object o = super.get(key);
       if (o instanceof String) {
@@ -132,7 +131,9 @@ class JsoMap extends JSONObject {
    * @return A JSONArray that contains all the keys.
    */
   JSONArray getKeys() {
-    return super.names();
+    // names() returns null if the array was empty!
+    JSONArray names = super.names();
+    return names != null ? names : new JSONArray();
   }
 
   /**
@@ -144,27 +145,26 @@ class JsoMap extends JSONObject {
    */
   @SuppressWarnings("unchecked")
   // JSONObject.keys() has no type information.
-      JsoMap getObj(String key)
-      throws ClassCastException, IllegalArgumentException {
-        try {
-          Object o = super.get(key);
-          if (o instanceof JSONObject) {
-            JSONObject value = (JSONObject) o;
-            ArrayList<String> keys = new ArrayList<String>(value.length());
-            for (Iterator<String> it = value.keys(); it.hasNext();) {
-              keys.add(it.next());
-            }
-            String[] names = new String[keys.size()];
-            return new JsoMap(value, keys.toArray(names));
-          } else if (o instanceof Integer) {
-            throw new IllegalArgumentException();
-          } else {
-            throw new ClassCastException();
-          }
-        } catch (JSONException e) {
-          return null;
+  JsoMap getObj(String key) throws ClassCastException, IllegalArgumentException {
+    try {
+      Object o = super.get(key);
+      if (o instanceof JSONObject) {
+        JSONObject value = (JSONObject) o;
+        ArrayList<String> keys = new ArrayList<String>(value.length());
+        for (Iterator<String> it = value.keys(); it.hasNext(); ) {
+          keys.add(it.next());
         }
+        String[] names = new String[keys.size()];
+        return new JsoMap(value, keys.toArray(names));
+      } else if (o instanceof Integer) {
+        throw new IllegalArgumentException();
+      } else {
+        throw new ClassCastException();
       }
+    } catch (JSONException e) {
+      return null;
+    }
+  }
 
   /**
    * Check if the object has specified key.
@@ -259,7 +259,7 @@ class JsoMap extends JSONObject {
       } catch (JSONException e) {
         throw new RuntimeException(e);
       }
-      sb.append('(').append(key).append(':').append(get(key)).append(')').append('\n');
+      sb.append('(').append(key).append(':').append(get(key)).append(")\n");
     }
     sb.append(']');
     return sb.toString();
@@ -275,8 +275,7 @@ class JsoMap extends JSONObject {
       } catch (JSONException e) {
         throw new RuntimeException(e);
       }
-      sb.append('(').append(key).append(':').append(getObj(key).string()).append(')')
-          .append('\n');
+      sb.append('(').append(key).append(':').append(getObj(key).string()).append(")\n");
     }
     sb.append(']');
     return sb.toString();

--- a/java/src/com/android/i18n/addressinput/LookupKey.java
+++ b/java/src/com/android/i18n/addressinput/LookupKey.java
@@ -21,26 +21,22 @@ import java.util.Map;
 
 /**
  * A builder for creating keys that are used to lookup data in the local cache and fetch data from
- * the server. There are two key types: {@code KeyType#DATA} or {@code KeyType#EXAMPLES}.
- *
- * <p> The {@code KeyType#DATA} key is built based on a universal Address hierarchy, which is:<br>
- *
- * {@code AddressField#Country} -> {@code AddressField#ADMIN_AREA} -> {@code AddressField#Locality}
- * -> {@code AddressField#DEPENDENT_LOCALITY} </p>
- *
- * <p> The {@code KeyType#EXAMPLES} key is built with the following format:<br>
- *
- * {@code AddressField#Country} -> {@code ScriptType} -> language. </p>
+ * the server. There are two key types: {@link KeyType#DATA} or {@link KeyType#EXAMPLES}.
+ * <p>
+ * The {@link KeyType#DATA} key is built based on a universal Address hierarchy, which is:<br>
+ * {@link AddressField#COUNTRY} -> {@link AddressField#ADMIN_AREA} -> {@link AddressField#LOCALITY}
+ * -> {@link AddressField#DEPENDENT_LOCALITY}
+ * <p>
+ * The {@link KeyType#EXAMPLES} key is built with the following format:<br>
+ * {@link AddressField#COUNTRY} -> {@link ScriptType} -> language. </p>
  */
 final class LookupKey {
-
   /**
    * Key types. Address Widget organizes address info based on key types. For example, if you want
    * to know how to verify or format an US address, you need to use {@link KeyType#DATA} to get
    * that info; if you want to get an example address, you use {@link KeyType#EXAMPLES} instead.
    */
   enum KeyType {
-
     /**
      * Key type for getting address data.
      */
@@ -55,13 +51,11 @@ final class LookupKey {
    * Script types. This is used for countries that do not use Latin script, but accept it for
    * transcribing their addresses. For example, you can write a Japanese address in Latin script
    * instead of Japanese:
-   *
-   * <p> 7-2, Marunouchi 2-Chome, Chiyoda-ku, Tokyo 100-8799 </p>
-   *
+   * <pre>7-2, Marunouchi 2-Chome, Chiyoda-ku, Tokyo 100-8799 </pre>
+   * <p>
    * Notice that {@link ScriptType} is based on country/region, not language.
    */
   enum ScriptType {
-
     /**
      * The script that uses Roman characters like ABC (as opposed to scripts like Cyrillic or
      * Arabic).
@@ -80,7 +74,7 @@ final class LookupKey {
 
   /**
    * The universal address hierarchy. Notice that sub-administrative area is neglected here since
-   * it is not required to fill out address form.
+   * it is not required to fill out address forms.
    */
   private static final AddressField[] HIERARCHY = {
     AddressField.COUNTRY,
@@ -98,7 +92,7 @@ final class LookupKey {
 
   private final ScriptType scriptType;
 
-  // Values for hierarchy address fields.
+  // Values for each address field in the hierarchy.
   private final Map<AddressField, String> nodes;
 
   private final String keyString;
@@ -114,14 +108,14 @@ final class LookupKey {
   }
 
   /**
-   * Gets lookup key for the input address field. This method does not allow key with key type of
-   * {@link KeyType#EXAMPLES}.
+   * Gets a lookup key built from the values of nodes in the hierarchy up to and including the input
+   * address field. This method does not allow keys with a key type of {@link KeyType#EXAMPLES}.
    *
    * @param field a field in the address hierarchy.
    * @return key of the specified address field. If address field is not in the hierarchy, or is
-   *         more granular than the current key has, returns null. For example, if your current
-   *         key is "data/US" (down to country level), and you want to get the key for Locality
-   *         (more granular than country), it will return null.
+   *         more granular than the data present in the current key, returns null. For example,
+   *         if your current key is "data/US" (down to COUNTRY level), and you want to get the key
+   *         for LOCALITY (more granular than COUNTRY), it will return null.
    */
   LookupKey getKeyForUpperLevelField(AddressField field) {
     if (keyType != KeyType.DATA) {
@@ -227,9 +221,12 @@ final class LookupKey {
     } else {
       if (nodes.containsKey(AddressField.COUNTRY)) {
         // Example key. E.g., "examples/TW/local/_default".
-        keyBuilder.append(SLASH_DELIM).append(nodes.get(AddressField.COUNTRY))
-            .append(SLASH_DELIM).append(scriptType.name().toLowerCase())
-            .append(SLASH_DELIM).append(DEFAULT_LANGUAGE);
+        keyBuilder.append(SLASH_DELIM)
+            .append(nodes.get(AddressField.COUNTRY))
+            .append(SLASH_DELIM)
+            .append(scriptType.name().toLowerCase())
+            .append(SLASH_DELIM)
+            .append(DEFAULT_LANGUAGE);
       }
     }
 
@@ -317,14 +314,12 @@ final class LookupKey {
      */
     Builder(String keyString) {
       String[] parts = keyString.split(SLASH_DELIM);
-      // Check some pre-conditions.
       if (!parts[0].equals(KeyType.DATA.name().toLowerCase())
           && !parts[0].equals(KeyType.EXAMPLES.name().toLowerCase())) {
         throw new RuntimeException("Wrong key type: " + parts[0]);
       }
       if (parts.length > HIERARCHY.length + 1) {
-        throw new RuntimeException(
-            "input key '" + keyString + "' deeper than supported hierarchy");
+        throw new RuntimeException("input key '" + keyString + "' deeper than supported hierarchy");
       }
       if (parts[0].equals("data")) {
         keyType = KeyType.DATA;

--- a/java/src/com/android/i18n/addressinput/RegionData.java
+++ b/java/src/com/android/i18n/addressinput/RegionData.java
@@ -17,9 +17,11 @@
 package com.android.i18n.addressinput;
 
 /**
- * A simple class to hold region data. Instances of this class are immutable.
+ * A simple class to hold region data.
  */
-class RegionData {
+// This class used to purport to be immutable, but it is no such thing.
+// TODO: Make this class actually immutable and not just pretending to be immutable.
+final class RegionData {
 
   private String key;
   private String name;
@@ -37,8 +39,8 @@ class RegionData {
    */
   private RegionData(RegionData data) {
     Util.checkNotNull(data);
-    key = data.key;
-    name = data.name;
+    this.key = data.key;
+    this.name = data.name;
   }
 
   /**

--- a/java/src/com/android/i18n/addressinput/RegionDataConstants.java
+++ b/java/src/com/android/i18n/addressinput/RegionDataConstants.java
@@ -27,13 +27,10 @@ import java.util.Map;
  * and a list of all the regions that the widget can support. Data has been sorted below for ease of
  * editing.
  */
-class RegionDataConstants {
-
-  private static final Map<String, String> COUNTRY_FORMAT_MAP =
-      new HashMap<String, String>();
+final class RegionDataConstants {
+  private static final Map<String, String> COUNTRY_FORMAT_MAP = new HashMap<String, String>();
 
   private enum RegionDataEnum {
-
     AC(new String[]{
       "name", "ASCENSION ISLAND",
     }),

--- a/java/src/com/android/i18n/addressinput/StandardAddressVerifier.java
+++ b/java/src/com/android/i18n/addressinput/StandardAddressVerifier.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * Performs various consistency checks on an AddressData. This uses a {@link FieldVerifier} to check
  * each field in the address.
  */
-public class StandardAddressVerifier {
+public final class StandardAddressVerifier {
 
   private static final String LOCALE_DELIMITER = "--";
 
@@ -64,8 +64,11 @@ public class StandardAddressVerifier {
     this.problemMap = problemMap;
   }
 
+  /**
+   * Verifies the address, reporting problems to problems.
+   */
   public void verify(AddressData address, AddressProblems problems) {
-    NotifyingListener listener = new NotifyingListener(this);
+    NotifyingListener listener = new NotifyingListener();
     verifyAsync(address, problems, listener);
     try {
       listener.waitLoadingEnd();
@@ -74,8 +77,8 @@ public class StandardAddressVerifier {
     }
   }
 
-  public void verifyAsync(AddressData address, AddressProblems problems,
-      DataLoadListener listener) {
+  public void verifyAsync(
+      AddressData address, AddressProblems problems, DataLoadListener listener) {
     Thread verifier = new Thread(new Verifier(address, problems, listener));
     verifier.start();
   }
@@ -130,10 +133,13 @@ public class StandardAddressVerifier {
         }
       }
 
-      String street = Util.joinAndSkipNulls("\n", address.getAddressLine1(),
-          address.getAddressLine2());
+    // This concatenation is for the purpose of validation only - the important part is to check we
+    // have at least one value filled in for lower-level components.
+      String street =
+          Util.joinAndSkipNulls("\n", address.getAddressLine1(),
+              address.getAddressLine2());
 
-      // remaining calls don't change the field verifier
+      // Remaining calls don't change the field verifier.
       verifyField(script, v, POSTAL_CODE, address.getPostalCode(), problems);
       verifyField(script, v, STREET_ADDRESS, street, problems);
       verifyField(script, v, SORTING_CODE, address.getSortingCode(), problems);
@@ -185,9 +191,8 @@ public class StandardAddressVerifier {
   /**
    * Hook for adding special checks for particular problems and/or fields.
    */
-  protected boolean verifyProblemField(LookupKey.ScriptType script,
-      FieldVerifier verifier, AddressProblemType problem, AddressField field,
-      String datum, AddressProblems problems) {
+  protected boolean verifyProblemField(LookupKey.ScriptType script, FieldVerifier verifier,
+      AddressProblemType problem, AddressField field, String datum, AddressProblems problems) {
     return verifier.check(script, problem, field, datum, problems);
   }
 }

--- a/java/src/com/android/i18n/addressinput/StandardChecks.java
+++ b/java/src/com/android/i18n/addressinput/StandardChecks.java
@@ -16,6 +16,21 @@
 
 package com.android.i18n.addressinput;
 
+import static com.android.i18n.addressinput.AddressField.ADMIN_AREA;
+import static com.android.i18n.addressinput.AddressField.COUNTRY;
+import static com.android.i18n.addressinput.AddressField.DEPENDENT_LOCALITY;
+import static com.android.i18n.addressinput.AddressField.LOCALITY;
+import static com.android.i18n.addressinput.AddressField.ORGANIZATION;
+import static com.android.i18n.addressinput.AddressField.POSTAL_CODE;
+import static com.android.i18n.addressinput.AddressField.RECIPIENT;
+import static com.android.i18n.addressinput.AddressField.SORTING_CODE;
+import static com.android.i18n.addressinput.AddressField.STREET_ADDRESS;
+import static com.android.i18n.addressinput.AddressProblemType.INVALID_FORMAT;
+import static com.android.i18n.addressinput.AddressProblemType.MISMATCHING_VALUE;
+import static com.android.i18n.addressinput.AddressProblemType.MISSING_REQUIRED_FIELD;
+import static com.android.i18n.addressinput.AddressProblemType.UNEXPECTED_FIELD;
+import static com.android.i18n.addressinput.AddressProblemType.UNKNOWN_VALUE;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,8 +40,7 @@ import java.util.Map;
 /**
  * Loader for a map defining the standard checks to perform on AddressFields.
  */
-public class StandardChecks {
-
+public final class StandardChecks {
   private StandardChecks() {
   }
 
@@ -36,31 +50,21 @@ public class StandardChecks {
     Map<AddressField, List<AddressProblemType>> map =
         new HashMap<AddressField, List<AddressProblemType>>();
 
-    addToMap(map, AddressField.COUNTRY, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD, AddressProblemType.UNKNOWN_VALUE);
-    addToMap(map, AddressField.ADMIN_AREA, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD, AddressProblemType.UNKNOWN_VALUE);
-    addToMap(map, AddressField.LOCALITY, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD, AddressProblemType.UNKNOWN_VALUE);
-    addToMap(map, AddressField.DEPENDENT_LOCALITY, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD, AddressProblemType.UNKNOWN_VALUE);
-    addToMap(map, AddressField.POSTAL_CODE, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD, AddressProblemType.UNRECOGNIZED_FORMAT,
-        AddressProblemType.MISMATCHING_VALUE);
-    addToMap(map, AddressField.STREET_ADDRESS, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD);
-    addToMap(map, AddressField.SORTING_CODE, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD);
-    addToMap(map, AddressField.ORGANIZATION, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD);
-    addToMap(map, AddressField.RECIPIENT, AddressProblemType.USING_UNUSED_FIELD,
-        AddressProblemType.MISSING_REQUIRED_FIELD);
+    addToMap(map, COUNTRY, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD, UNKNOWN_VALUE);
+    addToMap(map, ADMIN_AREA, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD, UNKNOWN_VALUE);
+    addToMap(map, LOCALITY, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD, UNKNOWN_VALUE);
+    addToMap(map, DEPENDENT_LOCALITY, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD, UNKNOWN_VALUE);
+    addToMap(map, POSTAL_CODE, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD, INVALID_FORMAT,
+        MISMATCHING_VALUE);
+    addToMap(map, STREET_ADDRESS, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD);
+    addToMap(map, SORTING_CODE, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD);
+    addToMap(map, ORGANIZATION, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD);
+    addToMap(map, RECIPIENT, UNEXPECTED_FIELD, MISSING_REQUIRED_FIELD);
 
     PROBLEM_MAP = Collections.unmodifiableMap(map);
   }
 
-  private static void addToMap(Map<AddressField, List<AddressProblemType>> map,
-      AddressField field,
+  private static void addToMap(Map<AddressField, List<AddressProblemType>> map, AddressField field,
       AddressProblemType... problems) {
     map.put(field, Collections.unmodifiableList(Arrays.asList(problems)));
   }

--- a/java/src/com/android/i18n/addressinput/Util.java
+++ b/java/src/com/android/i18n/addressinput/Util.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 /**
  * Utility functions used by the address widget.
  */
-class Util {
+final class Util {
   /**
    * This variable is in upper-case, since we convert the language code to upper case before doing
    * string comparison.
@@ -36,6 +36,7 @@ class Util {
    * Map of countries that have non-latin local names, with the language that their local names
    * are in. We only list a country here if we have the appropriate data. Only language sub-tags
    * are listed.
+   * TODO: Delete this: the information should be read from RegionDataConstants.java.
    */
   private static final Map<String, String> nonLatinLocalLanguageCountries =
       new HashMap<String, String>();
@@ -87,8 +88,7 @@ class Util {
    * malformed, returns "und".
    */
   static String getLanguageSubtag(String languageCode) {
-    final Pattern languageCodePattern = Pattern
-        .compile("(\\w{2,3})(?:[-_]\\w{4})?(?:[-_]\\w{2})?");
+    final Pattern languageCodePattern = Pattern.compile("(\\w{2,3})(?:[-_]\\w{4})?(?:[-_]\\w{2})?");
     Matcher m = languageCodePattern.matcher(languageCode);
     if (m.matches()) {
       return m.group(1).toLowerCase();
@@ -111,17 +111,18 @@ class Util {
   /**
    * Throws an exception if the object is null, with a generic error message.
    */
-  static void checkNotNull(Object o) throws NullPointerException {
-    checkNotNull(o, "This object should not be null.");
+  static <T> T checkNotNull(T o) {
+    return checkNotNull(o, "This object should not be null.");
   }
 
   /**
    * Throws an exception if the object is null, with the error message supplied.
    */
-  static void checkNotNull(Object o, String message) throws NullPointerException {
+  static <T> T checkNotNull(T o, String message) {
     if (o == null) {
       throw new NullPointerException(message);
     }
+    return o;
   }
 
   /**
@@ -163,9 +164,8 @@ class Util {
     }
     if (names != null) {
       if (names.length > keyLength) {
-        throw new IllegalStateException(
-            "names length (" + names.length + ") is greater than keys length (" +
-            keys.length + ")");
+        throw new IllegalStateException("names length (" + names.length
+            + ") is greater than keys length (" + keys.length + ")");
       }
       for (int i = 0; i < keyLength; i++) {
         // If we have less names than keys, we ignore all missing names. This happens
@@ -179,9 +179,8 @@ class Util {
     }
     if (lnames != null) {
       if (lnames.length > keyLength) {
-        throw new IllegalStateException(
-            "lnames length (" + lnames.length + ") is greater than keys length (" +
-            keys.length + ")");
+        throw new IllegalStateException("lnames length (" + lnames.length
+            + ") is greater than keys length (" + keys.length + ")");
       }
       for (int i = 0; i < keyLength; i++) {
         if (i < lnames.length && lnames[i].length() > 0) {

--- a/java/src/com/android/i18n/addressinput/testing/AddressDataMapLoader.java
+++ b/java/src/com/android/i18n/addressinput/testing/AddressDataMapLoader.java
@@ -19,6 +19,7 @@ package com.android.i18n.addressinput.testing;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,31 +27,30 @@ import java.util.Map;
  * Helper class to load JSON data for testing.
  */
 public class AddressDataMapLoader {
-
   private static final String DATA_PATH = "/countryinfo.txt";
 
   private AddressDataMapLoader() {
   }
 
-  public static final Map<String, String> DATA;
+  public static final Map<String, String> TEST_COUNTRY_DATA = loadImmutableTestDataMap();
 
-  static {
-    DATA = new HashMap<String, String>();
+  private static Map<String, String> loadImmutableTestDataMap() {
+    HashMap<String, String> map = new HashMap<String, String>();
     try {
-      BufferedReader br = new BufferedReader(
-          new InputStreamReader(AddressDataMapLoader.class.getResourceAsStream(DATA_PATH),
-            "utf-8"));
-      String line = null;
+      BufferedReader br = new BufferedReader(new InputStreamReader(
+          AddressDataMapLoader.class.getResourceAsStream(DATA_PATH), "UTF-8"));
+      String line;
       while (null != (line = br.readLine())) {
         line = line.trim();
         if (line.length() == 0 || line.charAt(0) == '#') {
           continue;
         }
         int x = line.indexOf('=');
-        DATA.put(line.substring(0, x), line.substring(x + 1));
+        map.put(line.substring(0, x), line.substring(x + 1));
       }
     } catch (IOException e) {
       System.err.println("unable to create map: " + e.getMessage());
     }
+    return Collections.unmodifiableMap(map);
   }
 }

--- a/java/test/com/android/i18n/addressinput/AddressDataTest.java
+++ b/java/test/com/android/i18n/addressinput/AddressDataTest.java
@@ -18,48 +18,131 @@ package com.android.i18n.addressinput;
 
 import junit.framework.TestCase;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Tests for the AddressData class.
  */
 public class AddressDataTest extends TestCase {
   private static final String ADDRESS_LINE = "First address line";
 
+  public void testAddressLineSimple() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("First line")
+        .setAddressLine2("Second line")
+        .build();
+    assertEquals("First line", address.getAddressLine1());
+    assertEquals("Second line", address.getAddressLine2());
+  }
+
+  public void testManyAddressLines() {
+    List<String> lines = Arrays.asList(new String[] {
+        "First line", "Second line", "Third line", "Fourth line", "Last line"});
+    AddressData address = new AddressData.Builder()
+        .setAddressLines(lines)
+        .build();
+    assertEquals(lines, address.getAddressLines());
+
+    // When accessing via specific line getters, any lines after 2 are concatenated to the second.
+    assertEquals("First line", address.getAddressLine1());
+    assertEquals("Second line, Third line, Fourth line, Last line", address.getAddressLine2());
+  }
+
   public void testSetAddressLine() {
     AddressData.Builder builder = new AddressData.Builder();
     builder = builder.setAddress("\n " + ADDRESS_LINE);
     AddressData ad = builder.build();
     assertEquals(ADDRESS_LINE, ad.getAddressLine1());
-    assertEquals(null, ad.getAddressLine2());
+    assertNull(ad.getAddressLine2());
   }
 
-  public void testAddressLineNormalisation() {
-    AddressData address = new AddressData.Builder().setAddressLine1(null)
-        .setAddressLine2(ADDRESS_LINE).build();
-    AddressData copiedAddress = new AddressData.Builder(address).build();
-    assertEquals(ADDRESS_LINE, copiedAddress.getAddressLine1());
-    assertEquals(null, copiedAddress.getAddressLine2());
+  public void testAddressLineNormalisationTrimsWhitespace() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("\t  Line with whitespace around it   ")
+        .build();
+    assertEquals("Line with whitespace around it", address.getAddressLine1());
+    assertNull(address.getAddressLine2());
   }
 
-  public void testAddressLineNormalisationWithNewLineCharacters() {
-    AddressData address =
-        new AddressData.Builder().setAddressLine1(ADDRESS_LINE + "\n" + ADDRESS_LINE).build();
-    AddressData copiedAddress = new AddressData.Builder(address).build();
-    assertEquals(ADDRESS_LINE, copiedAddress.getAddressLine1());
-    assertEquals(ADDRESS_LINE, copiedAddress.getAddressLine2());
+  public void testAddressLineNormalisationSplitsOnNewline() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("First line\nSecond line").build();
+    assertEquals("First line", address.getAddressLine1());
+    assertEquals("Second line", address.getAddressLine2());
+  }
+
+  public void testAddressLineNormalisationExcludesNull() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1(null)
+        .setAddressLine2("First non-null line")
+        .build();
+    assertEquals("First non-null line", address.getAddressLine1());
+    assertNull(address.getAddressLine2());
+  }
+
+  public void testAddressLineNormalisationExcludesEmptyOrWhitespace() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("")
+        .setAddressLine2("First non-empty line")
+        .build();
+    assertEquals("First non-empty line", address.getAddressLine1());
+    assertNull(address.getAddressLine2());
+  }
+
+  public void testAddressLineNormalisationComplex() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("  \n\t \t\n")
+        .setAddressLine2("   \n   First non-empty line   \n   \t ")
+        .build();
+    assertEquals("First non-empty line", address.getAddressLine1());
+    assertNull(address.getAddressLine2());
+  }
+
+  public void testAddressLineNormalisationManyEmbeddedLines() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("\nFirst line  \nSecond line  ")
+        .setAddressLine2("\n  Third line\n Last line \t ")
+        .build();
+    assertEquals("First line", address.getAddressLine1());
+    assertEquals("Second line, Third line, Last line", address.getAddressLine2());
+  }
+
+  public void testBuilderSplitsLinesLazily() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("First line\nSecond line")
+        // The first address line hasn't been split yet, so resetting the 2nd line does nothing.
+        .setAddressLine2(null)
+        .build();
+    assertEquals("First line", address.getAddressLine1());
+    assertEquals("Second line", address.getAddressLine2());
+  }
+
+  public void testBuilderDoesNotReindexFieldsOnRemoval() {
+    AddressData address = new AddressData.Builder()
+        .setAddressLine1("First line (should be removed)")
+        .setAddressLine2("Second line (should be removed)")
+        // Removing the first line does not reindex the 2nd line to be the first line.
+        .setAddressLine1(null)
+        .setAddressLine2("Only line")
+        .build();
+    assertEquals("Only line", address.getAddressLine1());
+    assertNull(address.getAddressLine2());
   }
 
   public void testNoAdminArea() {
     AddressData address = new AddressData.Builder().build();
-    assertEquals(null, address.getAdministrativeArea());
+    assertNull(address.getAdministrativeArea());
   }
 
   public void testSetLanguageCode() throws Exception {
-    AddressData address = new AddressData.Builder().setCountry("TW")
-        // Taipei City
-        .setAdminArea("\u53F0\u5317\u5E02")
-        // Da-an District
-        .setLocality("\u5927\u5B89\u5340")
+    AddressData address = new AddressData.Builder()
+        .setCountry("TW")
+        .setAdminArea("\u53F0\u5317\u5E02")  // Taipei City
+        .setLocality("\u5927\u5B89\u5340")  // Da-an District
         .build();
+    // Actually, this address is not in Latin-script Chinese, but we are just testing that the
+    // language we set is the same as the one we get back.
     address = new AddressData.Builder(address).setLanguageCode("zh-latn").build();
     assertEquals("zh-latn", address.getLanguageCode());
   }

--- a/java/test/com/android/i18n/addressinput/AddressFieldTest.java
+++ b/java/test/com/android/i18n/addressinput/AddressFieldTest.java
@@ -22,7 +22,6 @@ import junit.framework.TestCase;
  * Tests for the AddressField enum.
  */
 public class AddressFieldTest extends TestCase {
-
   public void testOf() throws Exception {
     assertEquals(AddressField.COUNTRY, AddressField.of('R'));
   }

--- a/java/test/com/android/i18n/addressinput/AddressVerificationDataTest.java
+++ b/java/test/com/android/i18n/addressinput/AddressVerificationDataTest.java
@@ -24,9 +24,8 @@ import junit.framework.TestCase;
  * Tests to ensure that {@code AddressVerificationData} can parse all the default data.
  */
 public class AddressVerificationDataTest extends TestCase {
-
   private static final AddressVerificationData ADDRESS_DATA =
-      new AddressVerificationData(AddressDataMapLoader.DATA);
+      new AddressVerificationData(AddressDataMapLoader.TEST_COUNTRY_DATA);
 
   public void testParseAllData() {
     for (String key : ADDRESS_DATA.keys()) {
@@ -93,12 +92,12 @@ public class AddressVerificationDataTest extends TestCase {
   }
 
   public void testExampleData() {
-    assertNotNull("Expects example data.", AddressDataMapLoader.DATA.get("examples"));
+    assertNotNull("Expects example data.", AddressDataMapLoader.TEST_COUNTRY_DATA.get("examples"));
     assertNotNull("Expects example US address.",
-        AddressDataMapLoader.DATA.get("examples/US/local/en"));
+        AddressDataMapLoader.TEST_COUNTRY_DATA.get("examples/US/local/en"));
     assertEquals("'examples/TW/local/zh_Hant' and 'examples/TW/local/_default' should "
         + "return same value.",
-        AddressDataMapLoader.DATA.get("examples/TW/local/zh_Hant"),
-        AddressDataMapLoader.DATA.get("examples/TW/local/_default"));
+        AddressDataMapLoader.TEST_COUNTRY_DATA.get("examples/TW/local/zh_Hant"),
+        AddressDataMapLoader.TEST_COUNTRY_DATA.get("examples/TW/local/_default"));
   }
 }

--- a/java/test/com/android/i18n/addressinput/AddressWidgetUiComponentProviderTest.java
+++ b/java/test/com/android/i18n/addressinput/AddressWidgetUiComponentProviderTest.java
@@ -18,7 +18,6 @@ package com.android.i18n.addressinput;
 
 import com.android.i18n.addressinput.testing.TestActivity;
 
-import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.test.ActivityInstrumentationTestCase2;

--- a/java/test/com/android/i18n/addressinput/CacheDataTest.java
+++ b/java/test/com/android/i18n/addressinput/CacheDataTest.java
@@ -33,7 +33,7 @@ public class CacheDataTest extends AsyncTestCase {
 
   private static final String CALIFORNIA_KEY = "data/US/CA";
 
-  private static final String RANDOM_COUNTRY_KEY = "data/asIOSDxcowW";
+  private static final String INVALID_KEY = "data/asIOSDxcowW";
 
   private static final String EXAMPLE_LOCAL_US_KEY = "examples/US/local/_default";
 
@@ -56,7 +56,7 @@ public class CacheDataTest extends AsyncTestCase {
     String id = "data/CA";
     JSONObject jsonObject = null;
     try {
-      jsonObject = new JSONObject(AddressDataMapLoader.DATA.get(id));
+      jsonObject = new JSONObject(AddressDataMapLoader.TEST_COUNTRY_DATA.get(id));
     } catch (JSONException jsonException) {
       // If this throws an exception the test fails.
       fail("Can't parse json object");
@@ -73,7 +73,7 @@ public class CacheDataTest extends AsyncTestCase {
     // Creating cache with content.
     String id = "data/CA";
     try {
-      JSONObject jsonObject = new JSONObject(AddressDataMapLoader.DATA.get(id));
+      JSONObject jsonObject = new JSONObject(AddressDataMapLoader.TEST_COUNTRY_DATA.get(id));
       String jsonString = jsonObject.toString();
       jsonString = jsonString.substring(0, jsonString.length() / 2);
 
@@ -273,7 +273,7 @@ public class CacheDataTest extends AsyncTestCase {
   }
 
   public void testInvalidKey() {
-    final LookupKey key = new LookupKey.Builder(RANDOM_COUNTRY_KEY).build();
+    final LookupKey key = new LookupKey.Builder(INVALID_KEY).build();
 
     delayTestFinish(15000);
 

--- a/java/test/com/android/i18n/addressinput/FieldVerifierTest.java
+++ b/java/test/com/android/i18n/addressinput/FieldVerifierTest.java
@@ -21,19 +21,20 @@ import com.android.i18n.addressinput.testing.AddressDataMapLoader;
 import junit.framework.TestCase;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Spot check the standard data set for various cases of interest. This is not an exhaustive test.
+ * Spot check the standard dataset for various cases of interest.  This is not an exhaustive test.
  */
 public class FieldVerifierTest extends TestCase {
-
-  private static final StandardAddressVerifier VERIFIER =
-      new StandardAddressVerifier(new FieldVerifier(
-          new AddressVerificationData(AddressDataMapLoader.DATA)));
+  private static final StandardAddressVerifier VERIFIER = new StandardAddressVerifier(
+      new FieldVerifier(new AddressVerificationData(AddressDataMapLoader.TEST_COUNTRY_DATA)));
 
   private AddressProblems problems = new AddressProblems();
 
@@ -43,46 +44,89 @@ public class FieldVerifierTest extends TestCase {
   }
 
   public void testUnitedStatesOk() {
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mountain View")
         .setAddress("1234 Somewhere")
-        .setPostalCode("94025").build();
+        .setPostalCode("94025")
+        .build();
     VERIFIER.verify(addr, problems);
-    assertTrue(problems.toString(), problems.isEmpty());  // no mismatch
+    assertTrue(problems.isEmpty());  // No mismatch.
+  }
+
+  /**
+   * Testing that UNEXPECTED_FIELD is returned for the US if a sorting code is used.
+   */
+  public void testUnitedStatesWithIllegalField() {
+    AddressData addr = new AddressData.Builder()
+        .setCountry("US")
+        .setAdminArea("CA")
+        .setLocality("Mountain View")
+        .setAddress("1234 Somewhere")
+        .setPostalCode("94025")
+        .setSortingCode("ABC")
+        .build();
+    VERIFIER.verify(addr, problems);
+    assertEquals(AddressProblemType.UNEXPECTED_FIELD,
+        problems.getProblem(AddressField.SORTING_CODE));
+  }
+
+  public void testFranceInvalidPostcode() {
+    // Post-code should be 5 digits long.
+    AddressData addr = new AddressData.Builder()
+        .setCountry("FR")
+        .setLocality("Paris")
+        .setAddress("1234 Rue Arc-en-ciel")
+        .setPostalCode("9425")
+        .build();
+    VERIFIER.verify(addr, problems);
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.INVALID_FORMAT, problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   public void testUnitedStatesZipMismatch() {
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mountain View")
-        .setPostalCode("12345").build();
+        .setPostalCode("12345")
+        .setAddress("Some Street")
+        .build();
     VERIFIER.verify(addr, problems);
 
+    assertFalse(problems.isEmpty());
     assertEquals(AddressProblemType.MISMATCHING_VALUE,
         problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   public void testUnitedStatesNotOk() {
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality(null)
         .setDependentLocality("Foo Bar")
-        .setPostalCode("12345").build();
+        .setPostalCode("12345")
+        .build();
     VERIFIER.verify(addr, problems);
 
+    assertFalse(problems.isEmpty());
     assertEquals(AddressProblemType.MISMATCHING_VALUE,
         problems.getProblem(AddressField.POSTAL_CODE));
     assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
         problems.getProblem(AddressField.LOCALITY));
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.STREET_ADDRESS));
   }
 
   public void testChinaOk() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Beijing Shi")
         .setLocality("Xicheng Qu")
         .setAddress("Yitiao Lu")
-        .setPostalCode("123456").build();
+        .setPostalCode("123456")
+        .build();
     VERIFIER.verify(addr, problems);
     assertTrue(problems.isEmpty());
   }
@@ -97,6 +141,7 @@ public class FieldVerifierTest extends TestCase {
     VERIFIER.verify(addr, problems);
     assertFalse(problems.isEmpty());
 
+    assertFalse(problems.isEmpty());
     // The administrative area matches a known value, so we shouldn't get any problem.
     assertNull(problems.getProblem(AddressField.ADMIN_AREA));
     assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
@@ -122,17 +167,19 @@ public class FieldVerifierTest extends TestCase {
   }
 
   public void testGermanAddress() {
-    AddressData addr = new AddressData.Builder().setCountry("DE")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("DE")
         .setLocality("Berlin")
         .setAddress("Huttenstr. 50")
         .setPostalCode("10553")
         .setOrganization("BMW AG Niederkassung Berlin")
-        .setRecipient("Herr Diefendorf").build();
+        .setRecipient("Herr Diefendorf")
+        .build();
 
     VERIFIER.verify(addr, problems);
     assertTrue(problems.isEmpty());
 
-    // Clones address but leave city empty.
+    // Clone the address and clear the city.
     addr = new AddressData.Builder().set(addr).setLocality(null).build();
 
     VERIFIER.verify(addr, problems);
@@ -141,93 +188,120 @@ public class FieldVerifierTest extends TestCase {
   }
 
   public void testIrishAddress() {
-    AddressData addr = new AddressData.Builder().setCountry("IE")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("IE")
         .setLocality("Dublin")
         .setAdminArea("Co. Dublin")
         .setAddress("7424 118 Avenue NW")
-        .setRecipient("Conan O'Brien").build();
+        .setRecipient("Conan O'Brien")
+        .build();
 
     VERIFIER.verify(addr, problems);
-    assertTrue(problems.toString(), problems.isEmpty());
+    assertTrue(problems.isEmpty());
 
-    // Clones address but leave county empty. This address should be valid
-    // since county is not required.
+    // Clones address but clears the county. This address should be valid since county is not
+    // required.
     addr = new AddressData.Builder().set(addr).setAdminArea(null).build();
 
     VERIFIER.verify(addr, problems);
-    assertTrue(problems.toString(), problems.isEmpty());
+    assertTrue(problems.isEmpty());
+  }
+
+  public void testChinaPostalCodeMismatchingFormat() {
+    // This post-code is 5 digits - which is only valid in Taiwan, not Beijing.
+    AddressData addr = new AddressData.Builder()
+        .setCountry("CN")
+        .setAdminArea("Beijing Shi")
+        .setLocality("Xicheng Qu")
+        .setPostalCode("12345")
+        .setAddressLine1("Street")
+        .build();
+    VERIFIER.verify(addr, problems);
+    assertFalse(problems.isEmpty());
+
+    assertEquals(AddressProblemType.INVALID_FORMAT, problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   public void testChinaPostalCodeBadFormat() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Beijing Shi")
         .setLocality("Xicheng Qu")
-        .setPostalCode("12345").build();
+        .setPostalCode("12345")
+        .setAddressLine1("Street")
+        .build();
     VERIFIER.verify(addr, problems);
 
-    assertEquals(AddressProblemType.UNRECOGNIZED_FORMAT,
-        problems.getProblem(AddressField.POSTAL_CODE));
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.INVALID_FORMAT, problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   /**
-   * If there is a postal code pattern for a certain country, and the input postal code is empty,
-   * it should not be reported as bad postal code format. Whether empty postal code is ok should
-   * be determined by checks for required fields.
+   * If there is a postal code pattern for a certain country, and the input postal code is empty, it
+   * should not be reported as an invalid postal code format. Whether or not an empty postal code is
+   * okay should be determined by checks for required fields.
    */
   public void testEmptyPostalCodeReportedAsGoodFormat() {
-    // Chilean address has a postal code format pattern, but does not require
-    // postal code. The following address is valid.
-    AddressData addr = new AddressData.Builder().setCountry("CL")
+    // Chilean address has a postal code format pattern, but does not require postal code. The
+    // following address is valid.
+    AddressData addr = new AddressData.Builder()
+        .setCountry("CL")
         .setAddressLine1("GUSTAVO LE PAIGE ST #159")
         .setAdminArea("Atacama")
-        .setLocality("San Pedro")
+        .setLocality("Huasco")
         .setPostalCode("")
         .build();
     VERIFIER.verify(addr, problems);
-    assertTrue(problems.toString(), problems.isEmpty());
+    assertTrue(problems.isEmpty());
 
-    problems.clear();
-
-    // Now check for US addresses, which require a postal code. The following
-    // address's postal code is wrong because it is missing a required field, not
-    // because it doesn't match the expected postal code pattern.
+    // Now check for US addresses, which require a postal code. The following address's postal code
+    // is wrong because it is missing a required field, not because it doesn't match the expected
+    // postal code pattern.
     addr = new AddressData.Builder().setCountry("US").setPostalCode("").build();
-    problems.clear();
     VERIFIER.verify(addr, problems);
 
+    assertFalse(problems.isEmpty());
     assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
         problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   public void testChinaTaiwanOk() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Taiwan")
         .setLocality("Taichung City")
         .setDependentLocality("Situn District")
         .setAddress("12345 Yitiao Lu")
-        .setPostalCode("407").build();
+        .setPostalCode("407")
+        .build();
     VERIFIER.verify(addr, problems);
     assertTrue(problems.isEmpty());
   }
 
   public void testChinaTaiwanUnknownDistrict() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressData addr = new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Taiwan")
         .setLocality("Taichung City")
         .setDependentLocality("Foo Bar")
-        .setPostalCode("400").build();
+        .setAddress("12345 Yitiao Lu")
+        .setPostalCode("400")
+        .build();
     VERIFIER.verify(addr, problems);
 
+    assertFalse(problems.isEmpty());
     assertEquals(AddressProblemType.UNKNOWN_VALUE,
         problems.getProblem(AddressField.DEPENDENT_LOCALITY));
   }
 
   public void testStreetVerification() {
-    // Missing street address
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    // Missing street address.
+    AddressData addr = new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mountain View")
-        .setPostalCode("94025").build();
+        .setPostalCode("94025")
+        .build();
 
     assertNull(addr.getAddressLine1());
     assertNull(addr.getAddressLine2());
@@ -239,78 +313,213 @@ public class FieldVerifierTest extends TestCase {
   }
 
   // Tests The Bahamas' address
-  public void failingtestBahamas() {
-    final AddressData address =
-        new AddressData.Builder().setAddress("Abaco Beach Resort & Boat Habour")
+  public void testBahamas() {
+    AddressData address = new AddressData.Builder()
+        .setAddress("Abaco Beach Resort & Boat Habour")
         .setLocality("Treasure Cay")
         .setAdminArea("Abaco")
-        .setCountry("BS").build();
+        .setCountry("BS")
+        .build();
     VERIFIER.verify(address, problems);
     assertTrue(problems.isEmpty());
   }
 
   public void testJapan() {
-    // Added AdminArea since address verification can't infer it from Kyoto City
-    // Commented out dependent locality since we don't have the data for this and in fact say
-    // that it shouldn't be used for Japan.
-    // TODO: support inference of higher levels from lower ones
-    final AddressData address = new AddressData.Builder()
+    AddressData address = new AddressData.Builder()
         .setRecipient("\u5BAE\u672C \u8302")  // SHIGERU_MIYAMOTO
         .setAddress("\u4E0A\u9CE5\u7FBD\u927E\u7ACB\u753A11\u756A\u5730")
-        .setAdminArea("\u4eac\u90fd\u5e9c")  // Kyoto prefecture, added
+        .setAdminArea("\u4eac\u90fd\u5e9c")  // Kyoto prefecture
         .setLocality("\u4EAC\u90FD\u5E02")  // Kyoto city
-        // .setDependentLocality("\u5357\u533A")
         .setCountry("JP")
-        .setPostalCode("601-8501").build();
+        .setPostalCode("601-8501")
+        .build();
     VERIFIER.verify(address, problems);
     assertTrue(problems.toString(), problems.isEmpty());
   }
 
   public void testJapanLatin() {
-    // added AdminArea since address verification can't infer it from Kyoto City
-    // commented out dependent locality since address verification doesn't use it
-    final AddressData address = new AddressData.Builder()
-        .setRecipient("Shigeru Miyamoto")  // SHIGERU_MIYAMOTO_ENGLISH
+    AddressData address = new AddressData.Builder()
+        .setRecipient("Shigeru Miyamoto")
         .setAddress("11-1 Kamitoba-hokotate-cho")
-        .setAdminArea("KYOTO")  // added
+        .setAdminArea("KYOTO")
         .setLocality("Kyoto")
-        // .setDependentLocality("Minami-ku")
         .setLanguageCode("ja_Latn")
         .setCountry("JP")
-        .setPostalCode("601-8501").build();
+        .setPostalCode("601-8501")
+        .build();
     VERIFIER.verify(address, problems);
     assertTrue(problems.isEmpty());
   }
 
   public void testJapanLatinInvalidAdmin() {
-    final AddressData address = new AddressData.Builder()
+    AddressData address = new AddressData.Builder()
         .setRecipient("Shigeru Miyamoto")  // SHIGERU_MIYAMOTO_ENGLISH
         .setAddress("11-1 Kamitoba-hokotate-cho")
         .setAdminArea("Fake Admin")
         .setLocality("Kyoto")
         .setLanguageCode("ja_Latn")
         .setCountry("JP")
-        .setPostalCode("601-8501").build();
+        .setPostalCode("601-8501")
+        .build();
     VERIFIER.verify(address, problems);
     assertFalse(problems.isEmpty());
-    assertEquals(AddressProblemType.UNKNOWN_VALUE,
+    assertEquals(AddressProblemType.UNKNOWN_VALUE, problems.getProblem(AddressField.ADMIN_AREA));
+  }
+
+  public void testUnrecognizedFormatCheckWithNoState_US() {
+    Map<AddressField, List<AddressProblemType>> customChecks =
+        new HashMap<AddressField, List<AddressProblemType>>();
+    AddressProblemType countryProblems[] = {
+      AddressProblemType.UNEXPECTED_FIELD,
+      AddressProblemType.MISSING_REQUIRED_FIELD,
+      AddressProblemType.UNKNOWN_VALUE };
+    customChecks.put(AddressField.COUNTRY,
+                     Collections.unmodifiableList(Arrays.asList(countryProblems)));
+    AddressProblemType postalCodeProblems[] = {
+      AddressProblemType.UNEXPECTED_FIELD,
+      AddressProblemType.MISSING_REQUIRED_FIELD,
+      AddressProblemType.INVALID_FORMAT,
+      AddressProblemType.MISMATCHING_VALUE };
+    customChecks.put(AddressField.POSTAL_CODE,
+                     Collections.unmodifiableList(Arrays.asList(postalCodeProblems)));
+    StandardAddressVerifier customVerifier = new StandardAddressVerifier(
+      new FieldVerifier(new AddressVerificationData(AddressDataMapLoader.TEST_COUNTRY_DATA)),
+      customChecks);
+
+    AddressData addr = new AddressData.Builder().setCountry("US").setPostalCode("0000").build();
+    customVerifier.verify(addr, problems);
+    assertFalse(problems.isEmpty());
+    // There should be a problem, complaining that the postal-code was invalid, since it doesn't
+    // match the pattern for any state.
+    assertEquals(AddressProblemType.INVALID_FORMAT,
+        problems.getProblem(AddressField.POSTAL_CODE));
+
+    AddressData goodAddr =
+        new AddressData.Builder().setCountry("US").setPostalCode("65213").build();
+
+    problems.clear();
+    customVerifier.verify(goodAddr, problems);
+    assertTrue(problems.toString(), problems.isEmpty());
+  }
+
+  /**
+   * Testing that verifying behaviour for one country doesn't cause the validator to have strange
+   * behaviour when reused for another country later.
+   */
+  public void testNoSideEffects() {
+    AddressData addressDE = new AddressData.Builder()
+        .setCountry("DE")
+        .setAdminArea("BY")
+        .build();
+
+    VERIFIER.verify(addressDE, problems);
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.STREET_ADDRESS));
+    assertEquals(AddressProblemType.UNEXPECTED_FIELD,
         problems.getProblem(AddressField.ADMIN_AREA));
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.POSTAL_CODE));
+
+
+    AddressData addressMX = new AddressData.Builder().setCountry("MX").build();
+
+    problems.clear();
+    VERIFIER.verify(addressMX, problems);
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.STREET_ADDRESS));
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.LOCALITY));
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.POSTAL_CODE));
+
+    problems.clear();
+    VERIFIER.verify(addressDE, problems);
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.STREET_ADDRESS));
+    assertEquals(AddressProblemType.UNEXPECTED_FIELD,
+        problems.getProblem(AddressField.ADMIN_AREA));
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.POSTAL_CODE));
+    assertNull(problems.getProblem(AddressField.LOCALITY));
+  }
+
+  public void testElSalvador() {
+    // The address should be valid both with and without a post-code.
+    AddressData addressNoPostcode = new AddressData.Builder()
+        .setAddress("Some Street 12")
+        // We have to have an admin area set here that exactly matches the *key* of the sub-region
+        // data in order for any more detailed verification data to be loaded.
+        .setAdminArea("AHUACHAPAN")
+        .setLocality("Ahuachapán")
+        .setCountry("SV")
+        .build();
+    VERIFIER.verify(addressNoPostcode, problems);
+    assertTrue(problems.isEmpty());
+
+    AddressData validAddress = new AddressData.Builder(addressNoPostcode)
+        .setPostalCode("CP 2101")
+        .build();
+    VERIFIER.verify(validAddress, problems);
+    assertTrue(problems.isEmpty());
+
+    AddressData addressInvalidNoPostCodePrefix = new AddressData.Builder(validAddress)
+        .setPostalCode("2101")
+        .build();
+    problems.clear();
+    VERIFIER.verify(addressInvalidNoPostCodePrefix, problems);
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.INVALID_FORMAT,
+        problems.getProblem(AddressField.POSTAL_CODE));
+
+    AddressData addressInvalidPostCodeDigits = new AddressData.Builder(validAddress)
+        .setPostalCode("CP 9876")
+        .build();
+    problems.clear();
+    VERIFIER.verify(addressInvalidPostCodeDigits, problems);
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.INVALID_FORMAT,
+        problems.getProblem(AddressField.POSTAL_CODE));
+
+    // Correct post-code, but not for this province.
+    AddressData addressInvalidPostCode = new AddressData.Builder(validAddress)
+        .setPostalCode("CP 2201")  // Santa Ana, not Ahuachapán.
+        .build();
+    problems.clear();
+    VERIFIER.verify(addressInvalidPostCode, problems);
+    assertFalse(problems.isEmpty());
+    assertEquals(AddressProblemType.MISMATCHING_VALUE,
+        problems.getProblem(AddressField.POSTAL_CODE));
+    assertNull(problems.getProblem(AddressField.ADMIN_AREA));
   }
 
   public void testCanadaMixedCasePostcode() {
-    final AddressData address = new AddressData.Builder()
+    AddressData address = new AddressData.Builder()
         .setRecipient("Joe Bloggs")
         .setAddress("11 East St")
         .setLocality("Montreal")
         .setAdminArea("Quebec")
         .setCountry("CA")
-        .setPostalCode("H2b 2y5").build();
+        .setPostalCode("H2b 2y5")
+        .build();
     VERIFIER.verify(address, problems);
     assertTrue(problems.isEmpty());
   }
 
+  public void testNoCountryProvided() {
+    AddressData address = new AddressData.Builder()
+        .setLanguageCode("en")
+        .build();
+    VERIFIER.verify(address, problems);
+    assertFalse(problems.toString(), problems.isEmpty());
+    assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
+        problems.getProblem(AddressField.COUNTRY));
+  }
+
   public void testMultipleAddressLines() {
-    final AddressData address = new AddressData.Builder()
+    AddressData address = new AddressData.Builder()
         .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mountain View")
@@ -323,12 +532,16 @@ public class FieldVerifierTest extends TestCase {
 
   public void testFieldVerifierUsesRegionDataConstantsForFmtAndRequire() {
     Map<AddressDataKey, String> map = new EnumMap<AddressDataKey, String>(AddressDataKey.class);
-    // Values for format and require are deliberately different from RegionDataConstants so that
-    // we can test that the RDC's version is preferred.
+    // Values for format and require are deliberately different from RegionDataConstants so that we
+    // can test that the RDC's version is preferred.
     map.put(AddressDataKey.FMT, "%N%n%O");
     map.put(AddressDataKey.REQUIRE, "A");
+    map.put(AddressDataKey.ZIP_NAME_TYPE, "postal");
+    map.put(AddressDataKey.STATE_NAME_TYPE, "region");
+    map.put(AddressDataKey.SUBLOCALITY_NAME_TYPE, "neighbourhood");
     map.put(AddressDataKey.SUB_KEYS, "Test");
     map.put(AddressDataKey.ID, "data/FM");
+    // In real life this represents the nodedata obtained from e.g. our metadata server.
     AddressVerificationNodeData testNode = new AddressVerificationNodeData(map);
     FieldVerifier fieldVerifier = new FieldVerifier(VERIFIER.rootVerifier, testNode);
 
@@ -336,11 +549,11 @@ public class FieldVerifierTest extends TestCase {
     Set<AddressField> expectedPossibleFields = EnumSet.of(AddressField.RECIPIENT,
         AddressField.ORGANIZATION, AddressField.STREET_ADDRESS, AddressField.LOCALITY,
         AddressField.ADMIN_AREA, AddressField.POSTAL_CODE, AddressField.COUNTRY);
-    Set<AddressField> expectedRequiredField = EnumSet.of(AddressField.STREET_ADDRESS,
+    Set<AddressField> expectedRequiredFields = EnumSet.of(AddressField.STREET_ADDRESS,
         AddressField.LOCALITY, AddressField.ADMIN_AREA, AddressField.POSTAL_CODE,
         AddressField.COUNTRY);
     assertEquals(expectedPossibleFields, fieldVerifier.possiblyUsedFields);
-    assertEquals(expectedRequiredField, fieldVerifier.required);
+    assertEquals(expectedRequiredFields, fieldVerifier.required);
     assertEquals("data/FM", fieldVerifier.id);
     // Keys should be populated from the test node.
     assertEquals("[Test]", Arrays.toString(fieldVerifier.keys));

--- a/java/test/com/android/i18n/addressinput/FormControllerTest.java
+++ b/java/test/com/android/i18n/addressinput/FormControllerTest.java
@@ -26,19 +26,17 @@ import java.util.List;
  */
 public class FormControllerTest extends AsyncTestCase {
 
-  private static final AddressData US_CA_ADDRESS;
-  private static final AddressData US_ADDRESS;
   private ClientData clientData;
 
-  static {
-    US_CA_ADDRESS = new AddressData.Builder().setCountry("US")
-        .setAdminArea("CA")
-        .setLocality("Mt View")
-        .setAddressLine1("1098 Alta Ave")
-        .setPostalCode("94043")
-        .build();
-    US_ADDRESS = new AddressData.Builder().setCountry("US").build();
-  }
+  private static final AddressData US_ADDRESS = new AddressData.Builder().setCountry("US").build();
+
+  private static final AddressData US_CA_ADDRESS = new AddressData.Builder()
+      .setCountry("US")
+      .setAdminArea("CA")
+      .setLocality("Mt View")
+      .setAddressLine1("1098 Alta Ave")
+      .setPostalCode("94043")
+      .build();
 
   @Override
   public void setUp() {

--- a/java/test/com/android/i18n/addressinput/FormatInterpreterTest.java
+++ b/java/test/com/android/i18n/addressinput/FormatInterpreterTest.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Tests for the FormatInterpreter class.
+ * Tests for {@link FormatInterpreter}.
  */
 public class FormatInterpreterTest extends TestCase {
   private static final AddressData US_CA_ADDRESS;
@@ -33,14 +33,16 @@ public class FormatInterpreterTest extends TestCase {
   private FormatInterpreter formatInterpreter;
 
   static {
-    US_CA_ADDRESS = new AddressData.Builder().setCountry("US")
+    US_CA_ADDRESS = new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mt View")
         .setAddressLine1("1098 Alta Ave")
         .setPostalCode("94043")
         .build();
 
-    TW_ADDRESS = new AddressData.Builder().setCountry("TW")
+    TW_ADDRESS = new AddressData.Builder()
+        .setCountry("TW")
         .setAdminArea("\u53F0\u5317\u5E02")  // Taipei city
         .setLocality("\u5927\u5B89\u5340")  // Da-an district
         .setAddressLine1("Sec. 3 Hsin-yi Rd.")
@@ -57,14 +59,13 @@ public class FormatInterpreterTest extends TestCase {
 
   public void testIterateUsAddressFields() {
     AddressField[] format = {
-      AddressField.RECIPIENT,
-      AddressField.ORGANIZATION,
-      AddressField.ADDRESS_LINE_1,
-      AddressField.ADDRESS_LINE_2,
-      AddressField.LOCALITY,
-      AddressField.ADMIN_AREA,
-      AddressField.POSTAL_CODE
-    };
+        AddressField.RECIPIENT,
+        AddressField.ORGANIZATION,
+        AddressField.ADDRESS_LINE_1,
+        AddressField.ADDRESS_LINE_2,
+        AddressField.LOCALITY,
+        AddressField.ADMIN_AREA,
+        AddressField.POSTAL_CODE};
 
     int currIndex = 0;
     for (AddressField field : formatInterpreter.getAddressFieldOrder(ScriptType.LOCAL, "US")) {
@@ -80,11 +81,11 @@ public class FormatInterpreterTest extends TestCase {
    */
   public void testIterateVuAddressFields() {
     AddressField[] format = {
-      AddressField.RECIPIENT,
-      AddressField.ORGANIZATION,
-      AddressField.ADDRESS_LINE_1,
-      AddressField.ADDRESS_LINE_2,
-      AddressField.LOCALITY,
+        AddressField.RECIPIENT,
+        AddressField.ORGANIZATION,
+        AddressField.ADDRESS_LINE_1,
+        AddressField.ADDRESS_LINE_2,
+        AddressField.LOCALITY,
     };
 
     int currIndex = 0;
@@ -97,21 +98,19 @@ public class FormatInterpreterTest extends TestCase {
 
   public void testOverrideFieldOrder() {
     AddressField[] expectedOrder = {
-      AddressField.ADMIN_AREA,
-      AddressField.ORGANIZATION,
-      AddressField.ADDRESS_LINE_1,
-      AddressField.ADDRESS_LINE_2,
-      AddressField.LOCALITY,
-      AddressField.RECIPIENT,
-      AddressField.POSTAL_CODE
-    };
+        AddressField.ADMIN_AREA,
+        AddressField.ORGANIZATION,
+        AddressField.ADDRESS_LINE_1,
+        AddressField.ADDRESS_LINE_2,
+        AddressField.LOCALITY,
+        AddressField.RECIPIENT,
+        AddressField.POSTAL_CODE};
 
     FormatInterpreter myInterpreter = new FormatInterpreter(
         new FormOptions.Builder().customizeFieldOrder("US",
-          AddressField.ADMIN_AREA,
-          AddressField.RECIPIENT,
-          AddressField.SORTING_CODE,
-          AddressField.POSTAL_CODE).build());
+            AddressField.ADMIN_AREA, AddressField.RECIPIENT,
+            AddressField.SORTING_CODE, AddressField.POSTAL_CODE)
+        .build());
 
     int currIndex = 0;
     for (AddressField field : myInterpreter.getAddressFieldOrder(ScriptType.LOCAL, "US")) {
@@ -127,14 +126,13 @@ public class FormatInterpreterTest extends TestCase {
 
   public void testIterateTwLatinAddressFields() {
     AddressField[] format = {
-      AddressField.RECIPIENT,
-      AddressField.ORGANIZATION,
-      AddressField.ADDRESS_LINE_1,
-      AddressField.ADDRESS_LINE_2,
-      AddressField.LOCALITY,
-      AddressField.ADMIN_AREA,
-      AddressField.POSTAL_CODE
-    };
+        AddressField.RECIPIENT,
+        AddressField.ORGANIZATION,
+        AddressField.ADDRESS_LINE_1,
+        AddressField.ADDRESS_LINE_2,
+        AddressField.LOCALITY,
+        AddressField.ADMIN_AREA,
+        AddressField.POSTAL_CODE};
 
     int currIndex = 0;
     for (AddressField field : formatInterpreter.getAddressFieldOrder(ScriptType.LATIN, "TW")) {
@@ -150,7 +148,6 @@ public class FormatInterpreterTest extends TestCase {
     expected.add("Mt View, CA 94043");
 
     List<String> real = formatInterpreter.getEnvelopeAddress(US_CA_ADDRESS);
-
     assertEquals(expected, real);
   }
 
@@ -174,11 +171,10 @@ public class FormatInterpreterTest extends TestCase {
     expected.add("1098 Alta Ave");
     expected.add("CA 94043");
 
-    AddressData address = new AddressData.Builder().set(US_CA_ADDRESS)
-        .set(AddressField.LOCALITY, null).build();
+    AddressData address =
+        new AddressData.Builder().set(US_CA_ADDRESS).set(AddressField.LOCALITY, null).build();
 
     List<String> real = formatInterpreter.getEnvelopeAddress(address);
-
     assertEquals(expected, real);
   }
 
@@ -193,7 +189,8 @@ public class FormatInterpreterTest extends TestCase {
   public void testEnvelopeAddressLeadingPostPrefix() {
     List<String> expected = new ArrayList<String>();
     expected.add("CH-8047 Herrliberg");
-    AddressData address = new AddressData.Builder().setCountry("CH")
+    AddressData address = new AddressData.Builder()
+        .setCountry("CH")
         .setPostalCode("8047")
         .setLocality("Herrliberg")
         .build();
@@ -203,7 +200,8 @@ public class FormatInterpreterTest extends TestCase {
   }
 
   public void testSvAddress() {
-    final AddressData svAddress = new AddressData.Builder().setCountry("SV")
+    AddressData svAddress = new AddressData.Builder()
+        .setCountry("SV")
         .setAdminArea("Ahuachapán")
         .setLocality("Ahuachapán")
         .setAddressLine1("Some Street 12")
@@ -217,9 +215,8 @@ public class FormatInterpreterTest extends TestCase {
     List<String> real = formatInterpreter.getEnvelopeAddress(svAddress);
     assertEquals(expected, real);
 
-    final AddressData svAddressWithPostCode = new AddressData.Builder(svAddress)
-        .setPostalCode("CP 2101")
-        .build();
+    AddressData svAddressWithPostCode =
+        new AddressData.Builder(svAddress).setPostalCode("CP 2101").build();
 
     expected = new ArrayList<String>();
     expected.add("Some Street 12");

--- a/java/test/com/android/i18n/addressinput/JsoMapTest.java
+++ b/java/test/com/android/i18n/addressinput/JsoMapTest.java
@@ -29,7 +29,6 @@ import java.util.Set;
  * Unit test for {@link JsoMap}.
  */
 public class JsoMapTest extends TestCase {
-
   private static final String VALID_JSON = "{\"a\":\"b\",\"c\":1,\"d\":{\"e\":\"f\"}}";
   private static final String INVALID_JSON = "!";
 

--- a/java/test/com/android/i18n/addressinput/LookupKeyTest.java
+++ b/java/test/com/android/i18n/addressinput/LookupKeyTest.java
@@ -77,9 +77,7 @@ public class LookupKeyTest extends TestCase {
   }
 
   public void testExampleKeys() {
-    AddressData address = new AddressData.Builder().setCountry("US")
-        .setLanguageCode("en")
-        .build();
+    AddressData address = new AddressData.Builder().setCountry("US").setLanguageCode("en").build();
 
     LookupKey key = new LookupKey.Builder(KeyType.EXAMPLES).setAddressData(address).build();
     assertEquals(EXAMPLE_LOCAL_US_KEY, key.toString());
@@ -100,9 +98,7 @@ public class LookupKeyTest extends TestCase {
 
   public void testFallbackToCountry() {
     // Admin Area is missing.
-    AddressData address = new AddressData.Builder().setCountry("US")
-        .setLocality("Mt View")
-        .build();
+    AddressData address = new AddressData.Builder().setCountry("US").setLocality("Mt View").build();
 
     LookupKey key = new LookupKey.Builder(KeyType.DATA).setAddressData(address).build();
 
@@ -117,11 +113,10 @@ public class LookupKeyTest extends TestCase {
   }
 
   public void testNonUsAddress() {
-    AddressData address = new AddressData.Builder().setCountry("TW")
-        // Taipei City
-        .setAdminArea("\u53F0\u5317\u5E02")
-        // Da-an District
-        .setLocality("\u5927\u5B89\u5340")
+    AddressData address = new AddressData.Builder()
+        .setCountry("TW")
+        .setAdminArea("\u53F0\u5317\u5E02")  // Taipei City
+        .setLocality("\u5927\u5B89\u5340")  // Da-an District
         .build();
 
     LookupKey key = new LookupKey.Builder(KeyType.DATA).setAddressData(address).build();
@@ -136,7 +131,8 @@ public class LookupKeyTest extends TestCase {
   }
 
   public void testGetKeyForUpperLevelFieldWithDataKey() {
-    AddressData address = new AddressData.Builder().setCountry("US")
+    AddressData address = new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mt View")
         .build();
@@ -174,7 +170,7 @@ public class LookupKeyTest extends TestCase {
     }
   }
 
-  public void testBuildKeyFromAddressWithLanguageSpecified() {
+  public void testGetParentKeyStartingFromAddressWithLanguageSpecified() {
     AddressData address = new AddressData.Builder().setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mt View")
@@ -201,8 +197,9 @@ public class LookupKeyTest extends TestCase {
     assertNull("root key's parent should be null", key);
   }
 
-  public void testGetParentKey() {
-    AddressData address = new AddressData.Builder().setCountry("US")
+  public void testGetParentKeyStartingFromAddress() {
+    AddressData address = new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mt View")
         .setDependentLocality("El Camino")
@@ -237,16 +234,16 @@ public class LookupKeyTest extends TestCase {
   }
 
   /**
-   * Ensures that even when the input key string is random, we still create a key. (We do not
-   * verify if the key maps to an real world entity like a city or country).
+   * Ensures that even when the input key string is random, we still create a key. (We do not verify
+   * if the key maps to an real world entity like a city or country).
    */
-  public void testWeDontVerifyKeyName() {
+  public void testWeDoNotVerifyKeyName() {
     LookupKey key = new LookupKey.Builder(RANDOM_COUNTRY_KEY).build();
     assertEquals(RANDOM_COUNTRY_KEY, key.toString());
   }
 
   public void testHash() {
-    String keys[] = { ROOT_KEY, ROOT_EXAMPLE_KEY, US_KEY, CALIFORNIA_KEY };
+    String keys[] = {ROOT_KEY, ROOT_EXAMPLE_KEY, US_KEY, CALIFORNIA_KEY};
     Map<LookupKey, String> map = new HashMap<LookupKey, String>();
 
     for (String key : keys) {

--- a/java/test/com/android/i18n/addressinput/StandardAddressVerifierTest.java
+++ b/java/test/com/android/i18n/addressinput/StandardAddressVerifierTest.java
@@ -24,18 +24,19 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Spot check the standard data set for various cases of interest. This is not an exhaustive test.
+ * Test cases for StandardAddressVerifier.
  */
 public class StandardAddressVerifierTest extends TestCase {
+  private static FieldVerifier createTestFieldVerifier() {
+    return new FieldVerifier(new ClientData(new CacheData()));
+  }
 
-  private AddressProblems problems = new AddressProblems();
-  private StandardAddressVerifier verifier;
-
-  @Override
-  protected void setUp() {
-    problems.clear();
-    verifier = new StandardAddressVerifier(new FieldVerifier(new ClientData(new CacheData())),
-        StandardChecks.PROBLEM_MAP);
+  private static AddressProblems verify(AddressData address) {
+    StandardAddressVerifier verifier =
+        new StandardAddressVerifier(createTestFieldVerifier(), StandardChecks.PROBLEM_MAP);
+    AddressProblems problems = new AddressProblems();
+    verifier.verify(address, problems);
+    return problems;
   }
 
   public void testCustomProblemMapRespected() {
@@ -44,10 +45,10 @@ public class StandardAddressVerifierTest extends TestCase {
         .setAddress("1234 Somewhere")
         .setPostalCode("9402")
         .build();
-    verifier.verify(usAddress, problems);
+    AddressProblems problems = verify(usAddress);
     assertFalse(problems.toString(), problems.isEmpty());
 
-    assertEquals(AddressProblemType.UNRECOGNIZED_FORMAT,
+    assertEquals(AddressProblemType.INVALID_FORMAT,
         problems.getProblem(AddressField.POSTAL_CODE));
     assertEquals(AddressProblemType.UNKNOWN_VALUE,
         problems.getProblem(AddressField.ADMIN_AREA));
@@ -60,7 +61,8 @@ public class StandardAddressVerifierTest extends TestCase {
     Map<AddressField, List<AddressProblemType>> customProblems =
         new HashMap<AddressField, List<AddressProblemType>>();
     StandardAddressVerifier emptyProblemVerifier = new StandardAddressVerifier(
-        new FieldVerifier(new ClientData(new CacheData())), customProblems);
+        new FieldVerifier(new ClientData(new CacheData())),
+        customProblems);
     problems.clear();
     emptyProblemVerifier.verify(usAddress, problems);
     // We aren't looking for any problems, so shouldn't find any.
@@ -68,52 +70,51 @@ public class StandardAddressVerifierTest extends TestCase {
 
     // Lastly try with a map that only looks for postal code problems.
     List<AddressProblemType> postalCodeProblems = new ArrayList<AddressProblemType>();
-    postalCodeProblems.add(AddressProblemType.UNRECOGNIZED_FORMAT);
+    postalCodeProblems.add(AddressProblemType.INVALID_FORMAT);
     postalCodeProblems.add(AddressProblemType.MISSING_REQUIRED_FIELD);
     customProblems.put(AddressField.POSTAL_CODE, postalCodeProblems);
 
     StandardAddressVerifier postalCodeProblemVerifier = new StandardAddressVerifier(
-        new FieldVerifier(new ClientData(new CacheData())), customProblems);
+        new FieldVerifier(new ClientData(new CacheData())),
+        customProblems);
     problems.clear();
     postalCodeProblemVerifier.verify(usAddress, problems);
     assertFalse(problems.toString(), problems.isEmpty());
-    assertEquals(AddressProblemType.UNRECOGNIZED_FORMAT,
+    assertEquals(AddressProblemType.INVALID_FORMAT,
         problems.getProblem(AddressField.POSTAL_CODE));
     assertNull(problems.getProblem(AddressField.ADMIN_AREA));
   }
 
   public void testUnitedStatesOk() {
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mountain View")
         .setAddress("1234 Somewhere")
         .setPostalCode("94025")
-        .build();
-    verifier.verify(addr, problems);
+        .build());
     assertTrue(problems.toString(), problems.isEmpty());  // no mismatch
   }
 
   public void testUnitedStatesZipMismatch() {
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mountain View")
         .setPostalCode("12345")
-        .build();
-    verifier.verify(addr, problems);
-
+        .build());
     assertEquals(AddressProblemType.MISMATCHING_VALUE,
         problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   public void testUnitedStatesNotOk() {
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality(null)
         .setDependentLocality("Foo Bar")
         .setPostalCode("12345")
-        .build();
-    verifier.verify(addr, problems);
-
+        .build());
     assertEquals(AddressProblemType.MISMATCHING_VALUE,
         problems.getProblem(AddressField.POSTAL_CODE));
     assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
@@ -121,186 +122,151 @@ public class StandardAddressVerifierTest extends TestCase {
   }
 
   public void testChinaOk() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Beijing Shi")
         .setLocality("Xicheng Qu")
         .setAddress("Yitiao Lu")
         .setPostalCode("123456")
-        .build();
-    verifier.verify(addr, problems);
+        .build());
     assertTrue(problems.toString(), problems.isEmpty());
   }
 
   public void testGermanAddress() {
-    AddressData addr = new AddressData.Builder().setCountry("DE")
+    AddressData address = new AddressData.Builder()
+        .setCountry("DE")
         .setLocality("Berlin")
         .setAddress("Huttenstr. 50")
         .setPostalCode("10553")
         .setOrganization("BMW AG Niederkassung Berlin")
         .setRecipient("Herr Diefendorf")
         .build();
-
-    verifier.verify(addr, problems);
+    AddressProblems problems = verify(address);
     assertTrue(problems.toString(), problems.isEmpty());
 
-    // Clones address but leave city empty.
-    addr = new AddressData.Builder().set(addr).setLocality(null).build();
-
-    verifier.verify(addr, problems);
+    // Clones address but clears the city.
+    address = new AddressData.Builder().set(address).setLocality(null).build();
+    problems = verify(address);
     assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
         problems.getProblem(AddressField.LOCALITY));
   }
 
   public void testIrishAddress() {
-    AddressData addr = new AddressData.Builder().setCountry("IE")
+    AddressData address = new AddressData.Builder()
+        .setCountry("IE")
         .setLocality("Dublin")
         .setAdminArea("Co. Dublin")
         .setAddress("7424 118 Avenue NW")
         .setRecipient("Conan O'Brien")
         .build();
-
-    verifier.verify(addr, problems);
+    AddressProblems problems = verify(address);
     assertTrue(problems.toString(), problems.isEmpty());
 
-    // Clones address but leave county empty. This address should be valid
-    // since county is not required.
-    addr = new AddressData.Builder().set(addr).setAdminArea(null).build();
-
-    verifier.verify(addr, problems);
+    // Clones address but clears county. This address should also be valid since county is not
+    // required.
+    address = new AddressData.Builder().set(address).setAdminArea(null).build();
+    problems = verify(address);
     assertTrue(problems.toString(), problems.isEmpty());
   }
 
   public void testChinaPostalCodeBadFormat() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Beijing Shi")
         .setLocality("Xicheng Qu")
         .setPostalCode("12345")
-        .build();
-    verifier.verify(addr, problems);
-
-    // ensure problem is unrecognized format and problem is in POSTAL_CODE
-    assertEquals(AddressProblemType.UNRECOGNIZED_FORMAT,
+        .build());
+    assertEquals(AddressProblemType.INVALID_FORMAT,
         problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   /**
    * If there is a postal code pattern for a certain country, and the input postal code is empty,
-   * it should not be reported as bad postal code format. Whether an empty postal code is ok
-   * should be determined by checks for required fields.
+   * it should not be reported as bad postal code format. Whether empty postal code is ok should
+   * be determined by checks for required fields.
    */
   public void testEmptyPostalCodeReportedAsGoodFormat() {
-    // Chilean address has a postal code format pattern, but does not require
-    // postal code. The following address is valid.
-    AddressData addr = new AddressData.Builder().setCountry("CL")
+    // Chilean address has a postal code format pattern, but does not require postal code. The
+    // following address is valid.
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("CL")
         .setAddressLine1("GUSTAVO LE PAIGE ST #159")
         .setAdminArea("Atacama")
         .setLocality("Alto del Carmen")
         .setPostalCode("")
-        .build();
-    verifier.verify(addr, problems);
+        .build());
     assertTrue(problems.toString(), problems.isEmpty());
+  }
 
-    problems.clear();
-
-    // Now checks for US addresses, which requires postal code. The following
-    // address's postal code is wrong because it misses required field, not
-    // because it mismatches expected postal code pattern.
-    addr = new AddressData.Builder().setCountry("US").setPostalCode("").build();
-    problems.clear();
-    verifier.verify(addr, problems);
-
+  public void testMissingPostalCodeReportedAsBadFormat() {
+    // Check for US addresses, which requires a postal code. The following address's postal code is
+    // wrong because it is missing a required field, not because the postal code doesn't match the
+    // administrative area.
+    AddressProblems problems =
+        verify(new AddressData.Builder().setCountry("US").setPostalCode("").build());
     assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
         problems.getProblem(AddressField.POSTAL_CODE));
   }
 
   public void testChinaTaiwanOk() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Taiwan")
         .setLocality("Taichung City")
         .setDependentLocality("Situn District")
         .setAddress("12345 Yitiao Lu")
         .setPostalCode("407")
-        .build();
-    verifier.verify(addr, problems);
+        .build());
     assertTrue(problems.toString(), problems.isEmpty());
   }
 
   public void testChinaTaiwanUnknownDistrict() {
-    AddressData addr = new AddressData.Builder().setCountry("CN")
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("CN")
         .setAdminArea("Taiwan")
         .setLocality("Taichung City")
         .setDependentLocality("Foo Bar")
         .setPostalCode("400")
-        .build();
-    verifier.verify(addr, problems);
-
+        .build());
     assertEquals(AddressProblemType.UNKNOWN_VALUE,
         problems.getProblem(AddressField.DEPENDENT_LOCALITY));
   }
 
   public void testStreetVerification() {
-    // missing street address
-    AddressData addr = new AddressData.Builder().setCountry("US")
+    // Missing street address
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setCountry("US")
         .setAdminArea("CA")
         .setLocality("Mountain View")
         .setPostalCode("94025")
-        .build();
-
-    assertNull(addr.getAddressLine1());
-    assertNull(addr.getAddressLine2());
-
-    verifier.verify(addr, problems);
-
+        .build());
     assertEquals(AddressProblemType.MISSING_REQUIRED_FIELD,
         problems.getProblem(AddressField.STREET_ADDRESS));
   }
 
-  // Tests The Bahamas' address
-  public void failingtestBahamas() {
-    final AddressData address =
-        new AddressData.Builder().setAddress("Abaco Beach Resort & Boat Habour")
-        .setLocality("Treasure Cay")
-        .setAdminArea("Abaco")
-        .setCountry("BS")
-        .build();
-    verifier.verify(address, problems);
-    assertTrue(problems.toString(), problems.isEmpty());
-  }
-
   public void testJapan() {
-    // added AdminArea since address verification can't infer it from Kyoto City
-    // commented out dependent locality since address verification doesn't use it
-    // TODO: support inference of higher levels from lower ones
-    // TODO: add dependent locality support for japan addresses
-    final AddressData address =
-        new AddressData.Builder()
-        .setRecipient("\u5BAE\u672C \u8302")  // SHIGERU_MIYAMOTO
-        .setAddress("\u4E0A\u9CE5\u7FBD\u927E\u7ACB\u753A11\u756A\u5730")
-        .setAdminArea("\u4eac\u90fd\u5e9c")  // Kyoto prefecture, added
-        .setLocality("\u4EAC\u90FD\u5E02")  // Kyoto city
-        // .setDependentLocality("\u5357\u533A")
-        .setCountry("JP")
-        .setPostalCode("601-8501")
-        .build();
-    verifier.verify(address, problems);
+    AddressProblems problems =
+        verify(new AddressData.Builder()
+            .setRecipient("\u5BAE\u672C \u8302")  // SHIGERU_MIYAMOTO
+            .setAddress("\u4E0A\u9CE5\u7FBD\u927E\u7ACB\u753A11\u756A\u5730")
+            .setAdminArea("\u4eac\u90fd\u5e9c")  // Kyoto prefecture
+            .setLocality("\u4EAC\u90FD\u5E02")  // Kyoto city
+            .setCountry("JP")
+            .setPostalCode("601-8501")
+            .build());
     assertTrue(problems.toString(), problems.isEmpty());
   }
 
   public void testJapanLatin() {
-    // added AdminArea since address verification can't infer it from Kyoto City
-    // commented out dependent locality since address verification doesn't use it
-    final AddressData address =
-        new AddressData.Builder()
-        .setRecipient("Shigeru Miyamoto")  // SHIGERU_MIYAMOTO_ENGLISH
+    AddressProblems problems = verify(new AddressData.Builder()
+        .setRecipient("Shigeru Miyamoto")
         .setAddress("11-1 Kamitoba-hokotate-cho")
-        .setAdminArea("KYOTO")  // Kyoto prefecture, added
+        .setAdminArea("KYOTO")  // Kyoto prefecture
         .setLocality("Kyoto")  // Kyoto city
-        // .setDependentLocality("Minami-ku")
         .setLanguageCode("ja_Latn")
         .setCountry("JP")
         .setPostalCode("601-8501")
-        .build();
-    verifier.verify(address, problems);
+        .build());
     assertTrue(problems.toString(), problems.isEmpty());
   }
 }

--- a/java/test/com/android/i18n/addressinput/UtilTest.java
+++ b/java/test/com/android/i18n/addressinput/UtilTest.java
@@ -21,11 +21,7 @@ import junit.framework.TestCase;
 import java.util.Locale;
 import java.util.Map;
 
-/**
- * Tests for util functions.
- */
 public class UtilTest extends TestCase {
-
   public void testIsExplicitLatinScript() throws Exception {
     // Should recognise Latin script in a variety of forms.
     assertTrue(Util.isExplicitLatinScript("zh-Latn"));
@@ -100,8 +96,7 @@ public class UtilTest extends TestCase {
     // No country in the Locale language.
     assertEquals("fr_latn", Util.getWidgetCompatibleLanguageCode(Locale.FRENCH, "CN"));
     // CJK language - but wrong country.
-    assertEquals("ko_latn",
-        Util.getWidgetCompatibleLanguageCode(Locale.KOREAN, "CN"));
+    assertEquals("ko_latn", Util.getWidgetCompatibleLanguageCode(Locale.KOREAN, "CN"));
     Locale chineseChina = new Locale("zh", "CN");
     assertEquals("zh_CN", Util.getWidgetCompatibleLanguageCode(chineseChina, "CN"));
   }
@@ -127,7 +122,7 @@ public class UtilTest extends TestCase {
   }
 
   public void testBuildNameToKeyMap() throws Exception {
-    String names[] = {"", "", "", "", "NEW PROVIDENCE" };
+    String names[] = {"", "", "", "", "NEW PROVIDENCE"};
     // We have one more key than name here.
     String keys[] = {"AB", "AC", "AD", "AE", "NP", "XX"};
     Map<String, String> result = Util.buildNameToKeyMap(keys, names, null);
@@ -141,7 +136,7 @@ public class UtilTest extends TestCase {
     Map<String, String> resultWithLatin = Util.buildNameToKeyMap(keys, null, names);
     // We should have the six keys and the one Latin-script name in the end result.
     assertEquals(keys.length + 1, resultWithLatin.size());
-    String lnames[] = { "Other name" };
+    String lnames[] = {"Other name"};
     resultWithLatin = Util.buildNameToKeyMap(keys, names, lnames);
     // We should have the keys, plus the names in lnames and names.
     assertEquals(keys.length + 2, resultWithLatin.size());


### PR DESCRIPTION
User-impacting changes:
-- AddressData: Deprecated getAddressLine1 and getAddressLine2 in AddressData, along with the Builder constructors (replacing with .builder() method in the address data class. Similar with setAddressLine1 and setAddressLine2.
-- AddressProblemType: Renamed enums UNRECOGNIZED_FORMAT to INVALID_FORMAT and USING_UNUSED_FIELD to UNEXPECTED_FIELD.
-- FormOptions: Removal of baseId and setter/getter methods.

Code improvements:
-- Handling custom field order in FormOptions
-- Normalization of address lines
-- Util - checkNotNull now returns the object being checked
-- NotifyingListener - the wait code has been fixed.

Other changes:
-- Extra tests
-- Documentation changes
-- Making classes final
-- Var name changes
-- Whitespace and line-break changes
-- Replacements in some locations of Android logging with standard Java logging.
