### PR TITLE
Use XML entity &quot; to represent double quotes in attribute values.

### DIFF
--- a/java/res/values/address_strings.xml
+++ b/java/res/values/address_strings.xml
@@ -44,7 +44,7 @@
 
     <string name="i18n_village_township" translation_description="A unit used in postal addresses in Malaysia, which is smaller than the city/town, and represents a village, township, or precinct. [CHAR LIMIT=30]">Village / Township</string>
 
-    <string name="i18n_address_line1_label" translation_description="Street-level part of an address, e.g. "18th Street, Unit 3". [CHAR LIMIT=30]">Street address</string>
+    <string name="i18n_address_line1_label" translation_description="Street-level part of an address, e.g. &quot;18th Street, Unit 3&quot;. [CHAR LIMIT=30]">Street address</string>
 
     <string name="i18n_pin_code_label" translation_description="PIN (Postal Index Number) Code. Values are numeric. Used in India. [CHAR LIMIT=30]">PIN code</string>
 


### PR DESCRIPTION
The nested double quotes were added by commit da973cf0 and cause a (not unexpected) compile error:

> java/res/values/address_strings.xml:46:108: Error: Element type "string" must be followed by either attribute specifications, ">" or "/>".
