### PR TITLE
Fix crash from constant data missing ID data

### DIFF
--- a/common/src/main/java/com/google/i18n/addressinput/common/CacheData.java
+++ b/common/src/main/java/com/google/i18n/addressinput/common/CacheData.java
@@ -338,7 +338,11 @@ public final class CacheData {
         key.getValueForUpperLevelField(AddressField.COUNTRY));
     if (data != null) {
       try {
-        cache.putObj(key.toString(), JsoMap.buildJsoMap(data));
+        JsoMap obj = JsoMap.buildJsoMap(data);
+        String id = Util.toLowerCaseLocaleIndependent(AddressDataKey.ID.toString());
+        String keyString = key.toString();
+        obj.put(id, keyString);
+        cache.putObj(keyString, obj);
       } catch (JSONException e) {
         logger.warning("Failed to parse data for key " + key + " from RegionDataConstants");
       }


### PR DESCRIPTION
It's possible for `StandardAddressVerifier.verifyFields()` to crash with:

```
Fatal Exception: java.lang.NullPointerException: Cannot use null as key
       at com.google.i18n.addressinput.common.Util.checkNotNull(Util.java:123)
       at com.google.i18n.addressinput.common.FieldVerifier.isCountryKey(FieldVerifier.java:439)
       at com.google.i18n.addressinput.common.FieldVerifier.populate(FieldVerifier.java:171)
       at com.google.i18n.addressinput.common.FieldVerifier.<init>(FieldVerifier.java:105)
       at com.google.i18n.addressinput.common.FieldVerifier.refineVerifier(FieldVerifier.java:283)
       at com.google.i18n.addressinput.common.StandardAddressVerifier$Verifier.run(StandardAddressVerifier.java:132)
       at com.google.i18n.addressinput.common.StandardAddressVerifier.verifyFields(StandardAddressVerifier.java:86)
```

This happens if `ClientData.fetchDataIfNotAvailable()` fails to fetch data from the server in `CacheData.fetchDynamicData()`, resulting in getting the data from the `RegionDataConstants` with `CacheData.getFromRegionDataConstants()`. The constants data lacks the `id` key values that are returned from the server, which is required by `FieldVerifier.isCountryKey()`.

This change fixes this by adding the `id` value for region constant data from its `LookupKey`.