### PR TITLE
Update Grit and Python

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -27,7 +27,7 @@ RE2: Used for validating postal code format.
 Most of these packages are available on Debian-like distributions. You can
 install them with this command:
 
-$ sudo apt-get install gyp ninja-build libgtest-dev python libre2-dev
+$ sudo apt-get install gyp ninja-build libgtest-dev python3 libre2-dev
 
 Make sure that your version of GYP is at least 0.1~svn1395. Older versions of
 GYP do not generate the Ninja build files correctly. You can download a
@@ -62,14 +62,18 @@ https://code.google.com/p/re2/
 Building the library involves generating an out/Default/build.ninja file and
 running ninja:
 
-$ export GYP_GENERATORS='ninja'
-$ gyp --depth .
-$ ninja -C out/Default
+```
+export GYP_GENERATORS='ninja'
+gyp --depth .
+ninja -C out/Default
+```
 
 Overriding paths defined in the *.gyp files can be done by setting the
 GYP_DEFINES environment variable before running gyp:
 
-$ export GYP_DEFINES="gtest_dir='/xxx/include' gtest_src_dir='/xxx'"
+```
+export GYP_DEFINES="gtest_dir='/xxx/include' gtest_src_dir='/xxx'"
+```
 
 # Test
 

--- a/cpp/grit.gyp
+++ b/cpp/grit.gyp
@@ -35,7 +35,7 @@
             '<(SHARED_INTERMEDIATE_DIR)/messages.h',
           ],
           'action': [
-            'python',
+            'python3',
             '<(grit_dir)/grit.py',
             '-i',
             'res/messages.grd',


### PR DESCRIPTION
The copy of Grit has not been updated in a long time. This CL moves grit to a recent commit (196aa4862969ddb8391969e3d483909c92d56dae) and switches to python3.