### PR TITLE
Reland snprintf fix

### DIFF
--- a/cpp/src/validating_util.cc
+++ b/cpp/src/validating_util.cc
@@ -84,8 +84,8 @@ bool UnwrapHeader(const char* header_prefix,
 void ValidatingUtil::Wrap(time_t timestamp, std::string* data) {
   assert(data != nullptr);
   char timestamp_string[2 + 3 * sizeof timestamp];
-  int size =
-      std::sprintf(timestamp_string, "%ld", static_cast<long>(timestamp));
+  int size = std::snprintf(timestamp_string, sizeof(timestamp_string), "%ld",
+                                             static_cast<long>(timestamp));
   assert(size > 0);
   assert(size < sizeof timestamp_string);
   (void)size;


### PR DESCRIPTION
This was accidentally reverted during a push of updates. Relanding
https://github.com/google/libaddressinput/commit/7004680a47abc4904c51af47a63064e905074cde