### PR TITLE
Avoid manual lifetime management of `std::string`

### DIFF
--- a/cpp/include/libaddressinput/null_storage.h
+++ b/cpp/include/libaddressinput/null_storage.h
@@ -35,7 +35,7 @@ class NullStorage : public Storage {
   ~NullStorage() override;
 
   // No-op.
-  void Put(const std::string& key, std::string* data) override;
+  void Put(const std::string& key, std::string data) override;
 
   // Always calls the |data_ready| callback function signaling failure.
   void Get(const std::string& key, const Callback& data_ready) const override;

--- a/cpp/include/libaddressinput/source.h
+++ b/cpp/include/libaddressinput/source.h
@@ -21,6 +21,7 @@
 
 #include <libaddressinput/callback.h>
 
+#include <optional>
 #include <string>
 
 namespace i18n {
@@ -41,7 +42,7 @@ namespace addressinput {
 class Source {
  public:
   using Callback =
-      i18n::addressinput::Callback<const std::string&, std::string*>;
+      i18n::addressinput::Callback<const std::string&, std::optional<std::string>>;
 
   virtual ~Source() = default;
 

--- a/cpp/include/libaddressinput/storage.h
+++ b/cpp/include/libaddressinput/storage.h
@@ -21,6 +21,7 @@
 #include <libaddressinput/callback.h>
 
 #include <string>
+#include <optional>
 
 namespace i18n {
 namespace addressinput {
@@ -45,13 +46,13 @@ namespace addressinput {
 class Storage {
  public:
   using Callback =
-      i18n::addressinput::Callback<const std::string&, std::string*>;
+      i18n::addressinput::Callback<const std::string&, std::optional<std::string>>;
 
   virtual ~Storage() = default;
 
   // Stores |data| for |key|, where |data| is an object allocated on the heap,
   // which Storage takes ownership of.
-  virtual void Put(const std::string& key, std::string* data) = 0;
+  virtual void Put(const std::string& key, std::string data) = 0;
 
   // Retrieves the data for |key| and invokes the |data_ready| callback.
   virtual void Get(const std::string& key,

--- a/cpp/src/null_storage.cc
+++ b/cpp/src/null_storage.cc
@@ -24,14 +24,11 @@ namespace addressinput {
 NullStorage::NullStorage() = default;
 NullStorage::~NullStorage() = default;
 
-void NullStorage::Put(const std::string& key, std::string* data) {
-  assert(data != nullptr);  // Sanity check.
-  delete data;
-}
+void NullStorage::Put(const std::string& key, std::string data) {}
 
 void NullStorage::Get(const std::string& key,
                       const Callback& data_ready) const {
-  data_ready(false, key, nullptr);
+  data_ready(false, key, std::nullopt);
 }
 
 }  // namespace addressinput

--- a/cpp/src/validating_storage.h
+++ b/cpp/src/validating_storage.h
@@ -44,7 +44,7 @@ class ValidatingStorage : public Storage {
   ~ValidatingStorage() override;
 
   // Storage implementation.
-  void Put(const std::string& key, std::string* data) override;
+  void Put(const std::string& key, std::string data) override;
 
   // Storage implementation.
   // If the data is invalid, then |data_ready| will be called with (false, key,

--- a/cpp/test/fake_storage.cc
+++ b/cpp/test/fake_storage.cc
@@ -23,19 +23,13 @@ namespace addressinput {
 
 FakeStorage::FakeStorage() = default;
 
-FakeStorage::~FakeStorage() {
-  for (const auto& pair : data_) {
-    delete pair.second;
-  }
-}
+FakeStorage::~FakeStorage() = default;
 
-void FakeStorage::Put(const std::string& key, std::string* data) {
-  assert(data != nullptr);
-  auto result = data_.emplace(key, data);
+void FakeStorage::Put(const std::string& key, std::string data) {
+  auto result = data_.emplace(key, std::move(data));
   if (!result.second) {
     // Replace data in existing entry for this key.
-    delete result.first->second;
-    result.first->second = data;
+    result.first->second = std::move(data);
   }
 }
 
@@ -44,7 +38,7 @@ void FakeStorage::Get(const std::string& key,
   auto data_it = data_.find(key);
   bool success = data_it != data_.end();
   data_ready(success, key,
-             success ? new std::string(*data_it->second) : nullptr);
+             success ? std::make_optional<std::string>(data_it->second) : std::nullopt);
 }
 
 }  // namespace addressinput

--- a/cpp/test/fake_storage.h
+++ b/cpp/test/fake_storage.h
@@ -65,11 +65,11 @@ class FakeStorage : public Storage {
   ~FakeStorage() override;
 
   // Storage implementation.
-  void Put(const std::string& key, std::string* data) override;
+  void Put(const std::string& key, std::string data) override;
   void Get(const std::string& key, const Callback& data_ready) const override;
 
  private:
-  std::map<std::string, std::string*> data_;
+  std::map<std::string, std::string> data_;
 };
 
 }  // namespace addressinput

--- a/cpp/test/mock_source.cc
+++ b/cpp/test/mock_source.cc
@@ -26,7 +26,7 @@ MockSource::~MockSource() = default;
 void MockSource::Get(const std::string& key, const Callback& data_ready) const {
   auto it = data_.find(key);
   bool success = it != data_.end();
-  data_ready(success, key, success ? new std::string(it->second) : nullptr);
+  data_ready(success, key, success ? it->second : std::optional<std::string>());
 }
 
 }  // namespace addressinput

--- a/cpp/test/null_storage_test.cc
+++ b/cpp/test/null_storage_test.cc
@@ -47,13 +47,12 @@ class NullStorageTest : public testing::Test {
   static const char kKey[];
 
  private:
-  void OnDataReady(bool success, const std::string& key, std::string* data) {
-    ASSERT_FALSE(success && data == nullptr);
+  void OnDataReady(bool success, const std::string& key, std::optional<std::string> data) {
+    ASSERT_FALSE(success && !data.has_value());
     success_ = success;
     key_ = key;
-    if (data != nullptr) {
-      data_ = *data;
-      delete data;
+    if (data.has_value()) {
+      data_ = std::move(data).value();
     }
   }
 };
@@ -63,7 +62,7 @@ const char NullStorageTest::kKey[] = "foo";
 TEST_F(NullStorageTest, Put) {
   // The Put() method should not do anything, so this test only tests that the
   // code compiles and that the call doesn't crash.
-  storage_.Put(kKey, new std::string("bar"));
+  storage_.Put(kKey, "bar");
 }
 
 TEST_F(NullStorageTest, Get) {

--- a/cpp/test/retriever_test.cc
+++ b/cpp/test/retriever_test.cc
@@ -134,13 +134,11 @@ class StaleStorage : public Storage {
 
   // Storage implementation.
   void Get(const std::string& key, const Callback& data_ready) const override {
-    data_ready(true, key, new std::string(kStaleWrappedData));
+    data_ready(true, key, kStaleWrappedData);
   }
 
-  void Put(const std::string& key, std::string* value) override {
-    ASSERT_TRUE(value != nullptr);
+  void Put(const std::string& key, std::string data) override {
     data_updated_ = true;
-    delete value;
   }
 
   bool data_updated_;

--- a/cpp/test/testdata_source.cc
+++ b/cpp/test/testdata_source.cc
@@ -155,16 +155,16 @@ void TestdataSource::Get(const std::string& key,
   prefixed_key += key;
   auto data_it = GetData(src_path_).find(prefixed_key);
   bool success = data_it != GetData(src_path_).end();
-  std::string* data = nullptr;
+  std::optional<std::string> data;
   if (success) {
-    data = new std::string(data_it->second);
+    data = data_it->second;
   } else {
     // URLs that start with "https://chromium-i18n.appspot.com/ssl-address/" or
     // "https://chromium-i18n.appspot.com/ssl-aggregate-address/" prefix, but do
     // not have associated data will always return "{}" with status code 200.
     // TestdataSource imitates this behavior.
     success = true;
-    data = new std::string("{}");
+    data = "{}";
   }
   data_ready(success, key, data);
 }

--- a/cpp/test/testdata_source_test.cc
+++ b/cpp/test/testdata_source_test.cc
@@ -60,13 +60,12 @@ class TestdataSourceTest : public testing::TestWithParam<std::string> {
   const std::unique_ptr<const Source::Callback> data_ready_;
 
  private:
-  void OnDataReady(bool success, const std::string& key, std::string* data) {
-    ASSERT_FALSE(success && data == nullptr);
+  void OnDataReady(bool success, const std::string& key, std::optional<std::string> data) {
+    ASSERT_FALSE(success && !data.has_value());
     success_ = success;
     key_ = key;
-    if (data != nullptr) {
-      data_ = *data;
-      delete data;
+    if (data.has_value()) {
+      data_ = std::move(data).value();
     }
   }
 };


### PR DESCRIPTION
This change touches several places in `Source` and `Storage` where string was being passed as a pointer, with expectations for `delete` to be called once done with the value. There may even be a case in Chromium at the moment where one of these calls may be leaking memory due to how the memory is expected to managed.

This change passes the string by value, and in cases where the value may be omitted the string is wrapped on a `std::optional`.

Bug: https://issues.chromium.org/issues/423542167